### PR TITLE
feat: per-component changelog-based prerelease versioning

### DIFF
--- a/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch
+++ b/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch
@@ -1,8 +1,37 @@
+diff --git a/build/src/manifest.d.ts b/build/src/manifest.d.ts
+index bac02ad92f6ae9738a72615b7a073b12e29217f9..29d17661d6a15c2ff6b4f828775cddcf20312774 100644
+--- a/build/src/manifest.d.ts
++++ b/build/src/manifest.d.ts
+@@ -1,3 +1,4 @@
++import { Commit } from './commit';
+ import { ChangelogSection } from './changelog-notes';
+ import { GitHub, GitHubRelease } from './github';
+ import { Version } from './version';
+@@ -239,6 +240,7 @@ export declare class Manifest {
+     readonly plugins: ManifestPlugin[];
+     private _strategiesByPath?;
+     private _pathsByComponent?;
++    _commitsPerPath: Record<string, Commit[]>;
+     private manifestPath;
+     private bootstrapSha?;
+     private lastReleaseSha?;
+diff --git a/build/src/manifest.js b/build/src/manifest.js
+index db31d247db8a017ff3200e51c936628e68817bde..ecbfa227d30489ab51a397d45719d1ec04204a9d 100644
+--- a/build/src/manifest.js
++++ b/build/src/manifest.js
+@@ -314,6 +314,7 @@ class Manifest {
+         }
+         const commitExclude = new commit_exclude_1.CommitExclude(this.repositoryConfig);
+         commitsPerPath = commitExclude.excludeCommits(commitsPerPath);
++        this._commitsPerPath = commitsPerPath;
+         // backfill latest release tags from manifest
+         for (const path in this.repositoryConfig) {
+             const latestRelease = releasesByPath[path];
 diff --git a/package.json b/package.json
-index 5785aaaf94842ec5f6ba66086acf3abd7d8ebcf6..917c755c34be662fded17191e15484e1ce07a2ec 100644
+index 5785aaaf94842ec5f6ba66086acf3abd7d8ebcf6..546a8afc97a636f145754b24281491828268e32e 100644
 --- a/package.json
 +++ b/package.json
-@@ -2,8 +2,24 @@
+@@ -2,8 +2,32 @@
    "name": "release-please",
    "version": "17.2.1",
    "description": "generate release PRs based on the conventionalcommits.org spec",
@@ -24,6 +53,14 @@ index 5785aaaf94842ec5f6ba66086acf3abd7d8ebcf6..917c755c34be662fded17191e15484e1
 +    "./version": {
 +      "types": "./build/src/version.d.ts",
 +      "default": "./build/src/version.js"
++    },
++    "./commit": {
++      "types": "./build/src/commit.d.ts",
++      "default": "./build/src/commit.js"
++    },
++    "./util/filter-commits": {
++      "types": "./build/src/util/filter-commits.d.ts",
++      "default": "./build/src/util/filter-commits.js"
 +    }
 +  },
    "scripts": {

--- a/actions/run-release-please/src/index.ts
+++ b/actions/run-release-please/src/index.ts
@@ -1,9 +1,9 @@
 import * as core from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 import { GitHub, Manifest } from "release-please";
+import { parseConventionalCommits } from "release-please/commit";
 import { BranchName } from "release-please/util/branch-name";
-import { TagName } from "release-please/util/tag-name";
-import { Version } from "release-please/version";
+import { filterCommits } from "release-please/util/filter-commits";
 
 import type { CreatedRelease, Strategy } from "release-please";
 
@@ -22,6 +22,7 @@ interface PrereleaseOptions {
 	channel: string;
 	shortSha: string;
 	existingVersions: VersionsMap;
+	commitsPerPath: Record<string, Array<{ sha: string; message: string }>>;
 }
 
 /**
@@ -140,6 +141,20 @@ const getStrategiesByPath = (
 	).getStrategiesByPath();
 
 /**
+ * Access Manifest._commitsPerPath which is populated by buildPullRequests()
+ * during createPullRequests(). Contains per-component commits since last release,
+ * already split by path and filtered by CommitExclude.
+ */
+const getCommitsPerPath = (
+	manifest: Manifest,
+): Record<string, Array<{ sha: string; message: string }>> =>
+	(
+		manifest as unknown as {
+			_commitsPerPath: Record<string, Array<{ sha: string; message: string }>>;
+		}
+	)._commitsPerPath;
+
+/**
  * Fetch .release-please-manifest.json from a given branch via the GitHub API.
  * Returns the parsed manifest or null if the branch/file does not exist.
  */
@@ -217,6 +232,7 @@ const computePrereleaseVersions = async (
 		channel,
 		shortSha,
 		existingVersions,
+		commitsPerPath,
 	} = options;
 
 	const { owner, repo } = context.repo;
@@ -290,8 +306,6 @@ const computePrereleaseVersions = async (
 	core.info(JSON.stringify(changedPackages, null, 2));
 	core.endGroup();
 
-	const octokit = getOctokit(token);
-
 	// Compute prerelease version for each changed package.
 	for (const [
 		path,
@@ -311,52 +325,31 @@ const computePrereleaseVersions = async (
 			continue;
 		}
 
-		// Get component via strategy -> handles normalization per release-type
-		const component = await strategy.getComponent();
+		// Get per-component commits already fetched by Manifest.buildPullRequests().
+		// These are split by path, filtered to since-last-release, and exclusions applied.
+		const pathCommits = commitsPerPath[path] ?? [];
 
-		// Get tag config from repositoryConfig (public, properly merged).
+		// Parse conventional commits and filter to changelog-worthy entries only.
+		// filterCommits defaults to standard sections (feat, fix, perf, revert visible)
+		// when changelogSections is undefined.
 		const config = manifest.repositoryConfig[path];
-
-		// Construct last release tag using release-please's TagName.
-		const lastVersion = Version.parse(currentVersion);
-
-		const lastTag = new TagName(
-			lastVersion,
-			component ?? undefined,
-			config.tagSeparator,
-			config.includeVInTag,
+		const parsed = parseConventionalCommits(
+			pathCommits.map((c) => ({ sha: c.sha, message: c.message })),
 		);
+		const worthy = filterCommits(parsed, config.changelogSections);
+		const commitCount = worthy.length;
 
-		const lastTagStr = lastTag.toString();
-
-		// Count commits since the last release tag via GitHub API.
-		let commitCount: number;
-		try {
-			const { data } = await octokit.rest.repos.compareCommitsWithBasehead({
-				owner,
-				repo,
-				basehead: `${lastTagStr}...${context.sha}`,
-			});
-
-			commitCount = data.ahead_by;
-		} catch {
-			// Tag doesn't exist (e.g., first release). Get total commit count via Link header.
-			const { headers } = await octokit.rest.repos.listCommits({
-				owner,
-				repo,
-				sha: context.sha,
-				per_page: 1,
-			});
-			const match = headers.link?.match(/page=(\d+)>; rel="last"/);
-			commitCount = match ? parseInt(match[1], 10) : 1;
-		}
+		// Component-scoped SHA: most recent commit touching this path.
+		// Falls back to HEAD SHA for dependency-triggered bumps with no direct commits.
+		const componentSha =
+			pathCommits.length > 0 ? pathCommits[0].sha.substring(0, 7) : shortSha;
 
 		// Build prerelease version and clean package version.
-		const version = `${nextVersion}-${channel}.${String(commitCount)}+${shortSha}`;
+		const version = `${nextVersion}-${channel}.${String(commitCount)}+${componentSha}`;
 		const packageVersion = `${nextVersion}-${channel}.${String(commitCount)}`;
 
 		core.info(
-			`  ${path}: ${currentVersion} -> ${version} (component=${String(component)}, lastTag=${lastTagStr}, commits=${String(commitCount)})`,
+			`  ${path}: ${currentVersion} -> ${version} (commits=${String(commitCount)}, componentSha=${componentSha})`,
 		);
 
 		versions[path] = { version, packageVersion, type: "prerelease" };
@@ -421,6 +414,7 @@ const computePrereleaseVersions = async (
 		channel: prereleaseChannel,
 		shortSha,
 		existingVersions: versions,
+		commitsPerPath: getCommitsPerPath(manifest),
 	});
 
 	core.startGroup("Final versions");

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,7 +4899,7 @@ __metadata:
 
 "release-please@patch:release-please@npm%3A17.2.1#~/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch":
   version: 17.2.1
-  resolution: "release-please@patch:release-please@npm%3A17.2.1#~/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch::version=17.2.1&hash=6ec9be"
+  resolution: "release-please@patch:release-please@npm%3A17.2.1#~/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch::version=17.2.1&hash=697b58"
   dependencies:
     "@conventional-commits/parser": "npm:^0.4.1"
     "@google-automations/git-file-utils": "npm:^3.0.0"
@@ -4934,7 +4934,7 @@ __metadata:
     yargs: "npm:^17.0.0"
   bin:
     release-please: build/src/bin/release-please.js
-  checksum: 10/5e6a47280afba04a5225f6e0aa40fef9f4c9eddba683429f633fda4b1c0f641b83c060106d51f587055ab3921123dd92d77a3d2ba4491eca4f49ce9d6242f5a7
+  checksum: 10/a23abab461c7e9f6ef81b17f2eaa4e3ca90d78dbd880568252686e0f0c3575af85e9363e2f1f7c40ef4460de4b97befc1871b94293ce87f7c25219b8589b80b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Refactor prerelease version computation to count only changelog-worthy conventional commits (feat, fix, perf, revert, breaking) per component instead of all repo-wide commits since the last tag. This makes prerelease versions deterministic and idempotent per component.

Key changes:
- Extend release-please patch to expose parseConventionalCommits, filterCommits, and save Manifest's internal commitsPerPath
- Replace compareCommitsWithBasehead API calls with reuse of Manifest's already-fetched per-component commit data
- Use component-scoped SHA (last commit touching the component) instead of HEAD SHA in version metadata
- Zero additional API calls for commit fetching