### PR TITLE
fix: propagate linked-versions releases to silent group siblings

### DIFF
--- a/actions/run-release-please/README.md
+++ b/actions/run-release-please/README.md
@@ -12,6 +12,8 @@ This action wraps [release-please](https://github.com/googleapis/release-please)
 
 On every run, the action calls `createReleases()` (to publish GitHub releases for merged release PRs) and `createPullRequests()` (to create or update release PRs for pending changes). This mirrors what `googleapis/release-please-action` does in manifest mode. Stable versions are extracted directly from the created release objects.
 
+When the consumer's `release-please-config.json` declares a `linked-versions` plugin, this action propagates the released version to every group member in the `versions` output. `createReleases()` only emits a release for packages that produced changelog content, so silent group members (whose manifest version was bumped by the linked-versions plugin without their own commits) would otherwise be missing from the output. With this propagation, every linked sibling appears with `type: "release"` at the same version as its released siblings.
+
 ### Prerelease channels
 
 When `prerelease-channel` is set (e.g., `beta`), the action computes prerelease versions for packages that have pending changes but haven't been released yet:

--- a/actions/run-release-please/README.md.hbs
+++ b/actions/run-release-please/README.md.hbs
@@ -10,6 +10,8 @@ This action wraps [release-please](https://github.com/googleapis/release-please)
 
 On every run, the action calls `createReleases()` (to publish GitHub releases for merged release PRs) and `createPullRequests()` (to create or update release PRs for pending changes). This mirrors what `googleapis/release-please-action` does in manifest mode. Stable versions are extracted directly from the created release objects.
 
+When the consumer's `release-please-config.json` declares a `linked-versions` plugin, this action propagates the released version to every group member in the `versions` output. `createReleases()` only emits a release for packages that produced changelog content, so silent group members (whose manifest version was bumped by the linked-versions plugin without their own commits) would otherwise be missing from the output. With this propagation, every linked sibling appears with `type: "release"` at the same version as its released siblings.
+
 ### Prerelease channels
 
 When `prerelease-channel` is set (e.g., `beta`), the action computes prerelease versions for packages that have pending changes but haven't been released yet:

--- a/actions/run-release-please/src/index.ts
+++ b/actions/run-release-please/src/index.ts
@@ -312,6 +312,83 @@ const fetchChangedManifestEntries = async (options: {
 };
 
 /**
+ * Synchronize stable release versions across linked-version groups.
+ *
+ * Manifest.createReleases() only emits a CreatedRelease for paths whose
+ * strategy produced changelog-worthy output. Linked-versions group members
+ * without their own commits get their manifest version bumped silently and
+ * never appear in createReleases(), which leaves them out of `versions`
+ * even though they share the same released version as their group siblings.
+ *
+ * For every linked-versions plugin, this fills in missing group members
+ * with the release entry of any sibling that did appear in createReleases().
+ * Must run after extractStableVersions() and before computePrereleaseVersions(),
+ * so prerelease computation correctly skips paths that are now known to be
+ * stable releases.
+ */
+const syncLinkedReleaseVersions = async (options: {
+	manifest: Manifest;
+	strategiesByPath: Record<string, Strategy>;
+	versions: VersionsMap;
+}): Promise<void> => {
+	const { manifest, strategiesByPath, versions } = options;
+	const plugins = (
+		manifest as unknown as {
+			plugins: Array<{ groupName?: string; components?: Set<string> }>;
+		}
+	).plugins;
+
+	for (const plugin of plugins) {
+		if (!plugin.components) {
+			continue;
+		}
+
+		const groupLabel = plugin.groupName ?? "unnamed";
+
+		// Map component names to paths for this linked group.
+		const groupPaths: string[] = [];
+		for (const [path, strategy] of Object.entries(strategiesByPath)) {
+			const component = await strategy.getComponent();
+			if (component && plugin.components.has(component)) {
+				groupPaths.push(path);
+			}
+		}
+
+		// Pick the first released sibling as the template for this group.
+		// Linked-versions guarantees all members share the same manifest
+		// version after a merge; warn (but don't fail) if they don't.
+		let templateEntry: VersionEntry | undefined;
+		for (const path of groupPaths) {
+			if (!(path in versions) || versions[path].type !== "release") {
+				continue;
+			}
+			const entry = versions[path];
+			if (!templateEntry) {
+				templateEntry = entry;
+			} else if (templateEntry.packageVersion !== entry.packageVersion) {
+				core.warning(
+					`Linked group "${groupLabel}" has members at differing versions (${templateEntry.packageVersion} vs ${entry.packageVersion}); using ${templateEntry.packageVersion}.`,
+				);
+			}
+		}
+
+		if (!templateEntry) {
+			continue;
+		}
+
+		// Fill missing siblings only — never overwrite an existing entry.
+		for (const path of groupPaths) {
+			if (!(path in versions)) {
+				core.info(
+					`  ${path}: synced release from linked group "${groupLabel}" -> ${templateEntry.version}`,
+				);
+				versions[path] = { ...templateEntry };
+			}
+		}
+	}
+};
+
+/**
  * Synchronize prerelease versions for linked-version groups.
  * The linked-versions plugin ensures all group members share the same base
  * version in release PRs. Mirror that for prerelease: if any group member
@@ -345,6 +422,14 @@ const syncLinkedPrereleaseVersions = async (options: {
 			if (component && plugin.components.has(component)) {
 				groupPaths.push(path);
 			}
+		}
+
+		// If any member is already a stable release for this run, the linked
+		// group is fully released; do not introduce prereleases.
+		if (
+			groupPaths.some((p) => p in versions && versions[p].type === "release")
+		) {
+			continue;
 		}
 
 		// Sum the commit counts and find the most recent SHA across all group
@@ -539,6 +624,17 @@ const computePrereleaseVersions = async (
 	let versions: VersionsMap = {};
 	if (createdReleases.length > 0) {
 		versions = extractStableVersions(createdReleases, shortSha);
+
+		// Propagate stable releases to all linked-versions group siblings.
+		// createReleases() only emits one CreatedRelease per package with
+		// changelog content; silent group members would otherwise be missing
+		// from `versions` even though they share the bumped manifest version.
+		const strategiesByPath = await getStrategiesByPath(manifest);
+		await syncLinkedReleaseVersions({
+			manifest,
+			strategiesByPath,
+			versions,
+		});
 
 		core.startGroup("Computed stable versions");
 		core.info(JSON.stringify(versions, null, 2));


### PR DESCRIPTION
## Summary

When a `linked-versions` group has members without changelog content, release-please's `createReleases()` does not emit a `CreatedRelease` for them — the linked-versions plugin still bumped their manifest version in lockstep with their siblings, but the action's `versions` output skipped them. Those silent siblings then fell through to the prerelease step and were promoted to a beta of the *next* version (e.g. `1.4.0-beta.24`) instead of appearing as releases at the current version (`1.3.0`), as observed on `abinnovision/seljs`.

This adds `syncLinkedReleaseVersions`, which fills missing group members with the release entry of any released sibling, runs between `extractStableVersions` and `computePrereleaseVersions`, and adds a defensive guard in `syncLinkedPrereleaseVersions` so partially-released groups never fall back to prerelease sync.

## Test plan

- [ ] Re-run the seljs release workflow on a scenario where some linked-group packages have changelog commits and others don't, and confirm every group member now appears in the `Release / Prepare` output as `type: "release"` at the same version.