### PR TITLE
feat(setup-k8s-tools): cache latest tag lookups for 24h

### DIFF
--- a/actions/setup-k8s-tools/src/latest-tag-cache.ts
+++ b/actions/setup-k8s-tools/src/latest-tag-cache.ts
@@ -1,0 +1,98 @@
+import * as cache from "@actions/cache";
+import * as core from "@actions/core";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { OctokitType } from "./tools.js";
+
+const CACHE_KEY_PREFIX = "setup-k8s-tools-latest";
+
+interface ResolveLatestTagInput {
+	cacheId: string;
+	owner: string;
+	repo: string;
+	tagFilter?: (tag: string) => boolean;
+}
+
+const resolveLatestTagFresh = async (
+	octokit: OctokitType,
+	input: Pick<ResolveLatestTagInput, "owner" | "repo" | "tagFilter">,
+): Promise<string> => {
+	const { data } = await octokit.rest.repos.listReleases({
+		owner: input.owner,
+		repo: input.repo,
+		per_page: 50,
+	});
+
+	const release = data.find((r) => input.tagFilter?.(r.tag_name) ?? true);
+	if (release) {
+		return release.tag_name;
+	}
+
+	throw new Error(`Could not find a release for ${input.owner}/${input.repo}`);
+};
+
+// UTC date bucket → cache rotates at most once per day.
+const computeBucket = (): string => new Date().toISOString().slice(0, 10);
+
+const buildCacheFilePath = (cacheId: string): string =>
+	path.join(
+		process.env["RUNNER_TEMP"] ?? os.tmpdir(),
+		"setup-k8s-tools",
+		"latest",
+		`${cacheId}.json`,
+	);
+
+const resolveLatestTagCached = async (
+	octokit: OctokitType,
+	input: ResolveLatestTagInput,
+): Promise<string> => {
+	const bucket = computeBucket();
+	const primaryKey = `${CACHE_KEY_PREFIX}-${input.cacheId}-${bucket}`;
+	const restorePrefix = `${CACHE_KEY_PREFIX}-${input.cacheId}-`;
+	const filePath = buildCacheFilePath(input.cacheId);
+
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+	const restoredKey = await cache.restoreCache([filePath], primaryKey, [
+		restorePrefix,
+	]);
+
+	if (restoredKey === primaryKey) {
+		try {
+			const raw = await fs.readFile(filePath, "utf8");
+			const { tag } = JSON.parse(raw) as { tag: string };
+			core.info(`${input.cacheId} latest tag restored from cache: ${tag}`);
+			return tag;
+		} catch (err) {
+			core.warning(
+				`Failed to read cached latest tag for ${input.cacheId}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+
+	const tag = await resolveLatestTagFresh(octokit, input);
+	core.info(`${input.cacheId} latest tag resolved fresh: ${tag}`);
+
+	try {
+		await fs.writeFile(
+			filePath,
+			JSON.stringify({ tag, resolvedAt: new Date().toISOString() }),
+		);
+		await cache.saveCache([filePath], primaryKey);
+	} catch (err) {
+		core.warning(
+			err instanceof Error
+				? `Failed to save latest-tag cache for ${input.cacheId}: ${err.message}`
+				: `Failed to save latest-tag cache for ${input.cacheId}`,
+		);
+	}
+
+	return tag;
+};
+
+export { resolveLatestTagCached };
+export type { ResolveLatestTagInput };

--- a/actions/setup-k8s-tools/src/tools.ts
+++ b/actions/setup-k8s-tools/src/tools.ts
@@ -1,23 +1,6 @@
+import { resolveLatestTagCached } from "./latest-tag-cache.js";
+
 import type { getOctokit } from "@actions/github";
-
-const resolveLatestTag = async (
-	octokit: OctokitType,
-	input: { owner: string; repo: string; tagFilter?: (tag: string) => boolean },
-): Promise<string> => {
-	const { data } = await octokit.rest.repos.listReleases({
-		owner: input.owner,
-		repo: input.repo,
-		per_page: 50,
-	});
-
-	// If a tagFilter is provided, find the first release that matches the filter. Otherwise, take the first release.
-	const release = data.find((r) => input.tagFilter?.(r.tag_name) ?? true);
-	if (release) {
-		return release.tag_name;
-	}
-
-	throw new Error(`Could not find a release for ${input.owner}/${input.repo}`);
-};
 
 export type OctokitType = ReturnType<typeof getOctokit>;
 
@@ -45,7 +28,8 @@ export const TOOLS: ToolConfig[] = [
 		async resolve(input, { octokit, platform, arch }) {
 			const tag =
 				input === "latest"
-					? await resolveLatestTag(octokit, {
+					? await resolveLatestTagCached(octokit, {
+							cacheId: "kube-score",
 							owner: "zegl",
 							repo: "kube-score",
 						})
@@ -64,7 +48,8 @@ export const TOOLS: ToolConfig[] = [
 		async resolve(input, { octokit, platform, arch }) {
 			const tag =
 				input === "latest"
-					? await resolveLatestTag(octokit, {
+					? await resolveLatestTagCached(octokit, {
+							cacheId: "kubeconform",
 							owner: "yannh",
 							repo: "kubeconform",
 						})
@@ -82,7 +67,8 @@ export const TOOLS: ToolConfig[] = [
 		async resolve(input, { octokit, platform, arch }) {
 			const tag =
 				input === "latest"
-					? await resolveLatestTag(octokit, {
+					? await resolveLatestTagCached(octokit, {
+							cacheId: "kustomize",
 							owner: "kubernetes-sigs",
 							repo: "kustomize",
 							tagFilter: (tag) => tag.startsWith("kustomize/v"),


### PR DESCRIPTION
## Summary

- When `setup-k8s-tools` is invoked with `latest` for any tool, the GitHub `listReleases` lookup now goes through a third cache layer keyed by a UTC date bucket (`setup-k8s-tools-latest-<tool>-YYYY-MM-DD`), so consecutive runs within the same day skip the API round-trip entirely.
- The new helper `latest-tag-cache.ts` wraps the previous inline `resolveLatestTag` with `@actions/cache`, using a prefix restore-key as a graceful fallback and treating any non-exact-match restore as stale (re-resolve + re-save under the new bucket).
- Pinned versions still bypass everything; the existing tool-cache and `@actions/cache` binary layers in `install.ts` are untouched.

## Test plan

- [ ] Trigger a workflow consuming `abinnovision/actions/setup-k8s-tools@<this branch>` twice with `kube-score: latest`; confirm the first run logs "resolved fresh" and the second logs "restored from cache".
- [ ] Verify pinned versions (e.g. `kube-score: v1.18.0`) still install without hitting the latest-tag cache path.