### PR TITLE
feat(setup-k8s-tools): add argocd CLI

### DIFF
--- a/actions/setup-k8s-tools/README.md
+++ b/actions/setup-k8s-tools/README.md
@@ -1,6 +1,6 @@
 # setup-k8s-tools
 
-Installs kubernetes tooling (kube-score, kubeconform, kustomize) with
+Installs kubernetes tooling (kube-score, kubeconform, kustomize, argocd) with
 GitHub Actions tool caching. Pass &#x27;latest&#x27; or a pinned version per tool;
 omit or leave empty to skip a tool.
 
@@ -11,6 +11,7 @@ omit or leave empty to skip a tool.
 | `kube-score`  | [zegl/kube-score](https://github.com/zegl/kube-score)                     | `vX.Y.Z`       | `v1.18.0`   |
 | `kubeconform` | [yannh/kubeconform](https://github.com/yannh/kubeconform)                 | `vX.Y.Z`       | `v0.6.4`    |
 | `kustomize`   | [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) | `vX.Y.Z`       | `v5.4.3`    |
+| `argocd`      | [argoproj/argo-cd](https://github.com/argoproj/argo-cd)                   | `vX.Y.Z`       | `v2.13.0`   |
 
 Each tool input accepts `"latest"` to resolve and install the newest release at runtime, a pinned version string (e.g. `"v5.4.3"`) for reproducible builds, or an empty string to skip that tool entirely. The resolved version is written to the corresponding output and used as the tool-cache key, so re-runs on the same runner skip redundant downloads.
 
@@ -44,6 +45,7 @@ This action can be used with different version ranges. The following ranges are 
 | `kube-score`   | Version to install ("latest" or e.g. "v1.18.0"). Empty = skip.  | No       | _empty_               |
 | `kubeconform`  | Version to install ("latest" or e.g. "v0.6.4"). Empty = skip.   | No       | _empty_               |
 | `kustomize`    | Version to install ("latest" or e.g. "v5.4.3"). Empty = skip.   | No       | _empty_               |
+| `argocd`       | Version to install ("latest" or e.g. "v2.13.0"). Empty = skip.  | No       | _empty_               |
 
 ## Outputs
 
@@ -52,3 +54,4 @@ This action can be used with different version ranges. The following ranges are 
 | `kube-score-version`  | Resolved kube-score version installed (empty if skipped).  |
 | `kubeconform-version` | Resolved kubeconform version installed (empty if skipped). |
 | `kustomize-version`   | Resolved kustomize version installed (empty if skipped).   |
+| `argocd-version`      | Resolved argocd version installed (empty if skipped).      |

--- a/actions/setup-k8s-tools/README.md.hbs
+++ b/actions/setup-k8s-tools/README.md.hbs
@@ -9,6 +9,7 @@
 | `kube-score` | [zegl/kube-score](https://github.com/zegl/kube-score) | `vX.Y.Z` | `v1.18.0` |
 | `kubeconform` | [yannh/kubeconform](https://github.com/yannh/kubeconform) | `vX.Y.Z` | `v0.6.4` |
 | `kustomize` | [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) | `vX.Y.Z` | `v5.4.3` |
+| `argocd` | [argoproj/argo-cd](https://github.com/argoproj/argo-cd) | `vX.Y.Z` | `v2.13.0` |
 
 Each tool input accepts `"latest"` to resolve and install the newest release at runtime, a pinned version string (e.g. `"v5.4.3"`) for reproducible builds, or an empty string to skip that tool entirely. The resolved version is written to the corresponding output and used as the tool-cache key, so re-runs on the same runner skip redundant downloads.
 

--- a/actions/setup-k8s-tools/action.yml
+++ b/actions/setup-k8s-tools/action.yml
@@ -1,7 +1,7 @@
 name: Setup Kubernetes Tools
 author: "abi group GmbH"
 description: |
-  Installs kubernetes tooling (kube-score, kubeconform, kustomize) with
+  Installs kubernetes tooling (kube-score, kubeconform, kustomize, argocd) with
   GitHub Actions tool caching. Pass 'latest' or a pinned version per tool;
   omit or leave empty to skip a tool.
 inputs:
@@ -21,6 +21,10 @@ inputs:
     description: 'Version to install ("latest" or e.g. "v5.4.3"). Empty = skip.'
     required: false
     default: ""
+  argocd:
+    description: 'Version to install ("latest" or e.g. "v2.13.0"). Empty = skip.'
+    required: false
+    default: ""
 outputs:
   kube-score-version:
     description: "Resolved kube-score version installed (empty if skipped)."
@@ -28,6 +32,8 @@ outputs:
     description: "Resolved kubeconform version installed (empty if skipped)."
   kustomize-version:
     description: "Resolved kustomize version installed (empty if skipped)."
+  argocd-version:
+    description: "Resolved argocd version installed (empty if skipped)."
 runs:
   using: node24
   main: dist/index.js

--- a/actions/setup-k8s-tools/src/install.ts
+++ b/actions/setup-k8s-tools/src/install.ts
@@ -1,6 +1,7 @@
 import * as cache from "@actions/cache";
 import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -88,10 +89,29 @@ export const installTool = async (
 		`Bearer ${ctx.token}`,
 	);
 
-	const extractedPath =
-		config.archiveType === "tar"
-			? await tc.extractTar(downloaded)
-			: await tc.extractZip(downloaded);
+	let extractedPath: string;
+	if (config.archiveType === "binary") {
+		const binName = platform === "windows" ? `${config.name}.exe` : config.name;
+		const binDir = path.join(
+			process.env["RUNNER_TEMP"] ?? os.tmpdir(),
+			"setup-k8s-tools",
+			config.name,
+			version,
+			"bin",
+		);
+		await fs.mkdir(binDir, { recursive: true });
+		const dest = path.join(binDir, binName);
+		await fs.copyFile(downloaded, dest);
+		if (platform !== "windows") {
+			await fs.chmod(dest, 0o755);
+		}
+		extractedPath = binDir;
+	} else {
+		extractedPath =
+			config.archiveType === "tar"
+				? await tc.extractTar(downloaded)
+				: await tc.extractZip(downloaded);
+	}
 
 	try {
 		await cache.saveCache([extractedPath], cacheKey);

--- a/actions/setup-k8s-tools/src/tools.ts
+++ b/actions/setup-k8s-tools/src/tools.ts
@@ -17,7 +17,7 @@ export interface ResolveContext {
 
 export interface ToolConfig {
 	name: string;
-	archiveType: "tar" | "zip";
+	archiveType: "tar" | "zip" | "binary";
 	resolve: (input: string, ctx: ResolveContext) => Promise<ToolResolution>;
 }
 
@@ -79,6 +79,26 @@ export const TOOLS: ToolConfig[] = [
 			return {
 				version,
 				downloadUrl: `https://github.com/kubernetes-sigs/kustomize/releases/download/${encodeURIComponent(tag)}/kustomize_${version}_${platform}_${arch}.tar.gz`,
+			};
+		},
+	},
+	{
+		name: "argocd",
+		archiveType: "binary",
+		async resolve(input, { octokit, platform, arch }) {
+			const tag =
+				input === "latest"
+					? await resolveLatestTagCached(octokit, {
+							cacheId: "argocd",
+							owner: "argoproj",
+							repo: "argo-cd",
+						})
+					: input;
+
+			const suffix = platform === "windows" ? ".exe" : "";
+			return {
+				version: tag,
+				downloadUrl: `https://github.com/argoproj/argo-cd/releases/download/${tag}/argocd-${platform}-${arch}${suffix}`,
 			};
 		},
 	},


### PR DESCRIPTION
## Summary

Adds the ArgoCD CLI as a new installable tool in `setup-k8s-tools`, alongside the existing kube-score, kubeconform, and kustomize tools. Extends `install.ts` with a `"binary"` archive type to support tools distributed as raw executables rather than archives. Download URLs were verified against live GitHub releases for all supported platform/arch combinations (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64).

## Test plan

- [ ] Use the action with `argocd: latest` and confirm `argocd` is on PATH
- [ ] Use the action with a pinned version e.g. `argocd: v2.13.0` and confirm correct version installed
- [ ] Confirm `argocd-version` output is set
- [ ] Confirm omitting `argocd` input skips installation without error