### PR TITLE
fix(gitops-deploy): use commit SHA instead of branch ref for ArgoCD diff

### DIFF
--- a/workflows/gitops-deploy/workflow.yaml
+++ b/workflows/gitops-deploy/workflow.yaml
@@ -518,7 +518,7 @@ jobs:
       - name: Perform ArgoCD diff
         id: argocd-diff
         env:
-          REVISION: ${{ github.event.pull_request.head.ref }}
+          REVISION: ${{ needs.check.outputs.commit-sha }}
           ARGOCD_APP: ${{ steps.argocd-app.outputs.application_name }}
         run: |
           set +e  # Don't exit on non-zero


### PR DESCRIPTION
## Summary

- The `argocd app diff` step was using `github.event.pull_request.head.ref` (a mutable branch name) as the revision, which could produce incorrect diffs if the branch was pushed to mid-run.
- Changed to use `needs.check.outputs.commit-sha`, which is already resolved deterministically in the `check` job and used for checkout throughout the workflow.

## Test Plan
- [ ] Open a PR against a gitops repo and verify the diff comment reflects the exact commit checked out, not the branch tip.