### PR TITLE
fix(run-release-please): skip stale PR branch versions in prerelease computation

### DIFF
--- a/actions/run-release-please/package.json
+++ b/actions/run-release-please/package.json
@@ -36,11 +36,13 @@
 	"dependencies": {
 		"@actions/core": "^3.0.1",
 		"@actions/github": "^9.1.1",
-		"release-please": "patch:release-please@npm%3A17.2.1#~/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch"
+		"release-please": "patch:release-please@npm%3A17.2.1#~/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch",
+		"semver": "^7.8.0"
 	},
 	"devDependencies": {
 		"@abinnovision/eslint-config-base": "^3.4.0",
 		"@abinnovision/prettier-config": "^2.2.0",
+		"@types/semver": "^7.7.1",
 		"@vercel/ncc": "^0.38.4",
 		"eslint": "^10.2.1",
 		"prettier": "^3.8.3",

--- a/actions/run-release-please/src/index.ts
+++ b/actions/run-release-please/src/index.ts
@@ -4,6 +4,7 @@ import { GitHub, Manifest } from "release-please";
 import { parseConventionalCommits } from "release-please/commit";
 import { BranchName } from "release-please/util/branch-name";
 import { filterCommits } from "release-please/util/filter-commits";
+import semver from "semver";
 
 import type { CreatedRelease, Strategy } from "release-please";
 
@@ -299,9 +300,17 @@ const fetchChangedManifestEntries = async (options: {
 			core.info(`  Found manifest on branch: ${branch}`);
 			for (const [path, version] of Object.entries(branchManifest)) {
 				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-				if (currentVersions[path]?.toString() !== version) {
-					changed[path] = version;
+				const current = currentVersions[path]?.toString();
+				if (!current || current === version) {
+					continue;
 				}
+				// Skip stale versions: a PR branch created before recent releases will
+				// carry an old snapshot of paths it doesn't own. Only accept versions
+				// that are strictly newer than what is currently released.
+				if (!semver.gt(version, current)) {
+					continue;
+				}
+				changed[path] = version;
 			}
 		} else {
 			core.info(`  No manifest on branch: ${branch}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,6 +1330,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.7.1":
+  version: 7.7.1
+  resolution: "@types/semver@npm:7.7.1"
+  checksum: 10/8f09e7e6ca3ded67d78ba7a8f7535c8d9cf8ced83c52e7f3ac3c281fe8c689c3fe475d199d94390dc04fc681d51f2358b430bb7b2e21c62de24f2bee2c719068
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:^2.0.0":
   version: 2.0.11
   resolution: "@types/unist@npm:2.0.11"
@@ -4159,10 +4166,12 @@ __metadata:
     "@abinnovision/prettier-config": "npm:^2.2.0"
     "@actions/core": "npm:^3.0.1"
     "@actions/github": "npm:^9.1.1"
+    "@types/semver": "npm:^7.7.1"
     "@vercel/ncc": "npm:^0.38.4"
     eslint: "npm:^10.2.1"
     prettier: "npm:^3.8.3"
     release-please: "patch:release-please@npm%3A17.2.1#~/.yarn/patches/release-please-npm-17.2.1-b0a2026871.patch"
+    semver: "npm:^7.8.0"
     typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
@@ -4185,12 +4194,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.6.0, semver@npm:^7.7.2, semver@npm:^7.7.3":
-  version: 7.7.4
-  resolution: "semver@npm:7.7.4"
+"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.6.0, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.0":
+  version: 7.8.0
+  resolution: "semver@npm:7.8.0"
   bin:
     semver: bin/semver.js
-  checksum: 10/26bdc6d58b29528f4142d29afb8526bc335f4fc04c4a10f2b98b217f277a031c66736bf82d3d3bb354a2f6a3ae50f18fd62b053c4ac3f294a3d10a61f5075b75
+  checksum: 10/039a8f68a581c03c1ac17c990316da57a79a93af9b109b712739c50cd4d464079f7e3fee31c008b472e390c7ba48a11ed2b86e91d8602bf06059d4a266db1426
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Fixes spurious prerelease Docker images (e.g. `1.9.0-beta.0`) being produced on release commits when other open release-please PR branches carry stale manifest snapshots for a path they don't own
- Root cause: `fetchChangedManifestEntries` checked for version inequality but not direction — a stale `1.9.0` from a branch created before `1.11.0` shipped would pass the guard and become the prerelease base
- Fix: add `semver.gt(version, current)` guard so only strictly newer versions from PR branches enter `changedEntries`; adds `semver` as a direct dependency with `@types/semver` for types

## Test plan

- [ ] Next release commit: confirm Release/Release job log shows no abigroup entry in "Manifest comparison / PR:" when abigroup has no pending changes after its release PR merges
- [ ] Confirm other apps' prerelease versions are unaffected (their own PR branches carry a newer version for their path, which still passes the `semver.gt` guard)