### PR TITLE
fix(polyglot-monorepo-stack): only deploy gh-pages on stable releases

### DIFF
--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -495,6 +495,7 @@ jobs:
           released_gh_pages_apps=$(echo "$VERSIONS" | jq --argjson pages "$GH_PAGES_APPS" -c \
             '[to_entries[]
               | select(.key | startswith("apps/"))
+              | select(.value.type == "release")
               | {app: (.key | ltrimstr("apps/")), version: .value.version, packageVersion: .value.packageVersion, type: .value.type, sha: .value.sha}
               | select(.app as $a | $pages | index($a) != null)
             ]')


### PR DESCRIPTION
## Summary

The `publish_gh_pages` job in `workflows/polyglot-monorepo-stack/workflow.yaml` was running on every push to the default branch that touched a gh-pages app, not just on stable releases. The `released_gh_pages_apps` extraction in `publish_prepare` filtered apps by key and availability but did not filter on `.value.type`, so `prerelease` entries from the release workflow's `versions` output also satisfied the `has-released-gh-pages-apps == 'true'` gate.

This PR adds `select(.value.type == "release")` to the jq pipeline, matching the existing check that `publish_apps` already performs.

## Test plan

- [ ] On a downstream consumer, push a non-release-bearing commit to a gh-pages app and confirm `publish_gh_pages` is skipped.
- [ ] Merge a release-please PR that bumps a gh-pages app and confirm `publish_gh_pages` runs exactly once and `deploy-pages` succeeds.