### PR TITLE
fix(polyglot): skip Publish / Prepare job on pull requests

### DIFF
--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -470,7 +470,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     needs: [configure, release]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && needs.release.outputs.versions != '{}'
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && needs.release.result == 'success' && needs.release.outputs.versions != '{}'
     outputs:
       released-apps: ${{ steps.extract.outputs.released_apps }}
       has-released-apps: ${{ steps.extract.outputs.has_released_apps }}


### PR DESCRIPTION
The `publish_prepare` ("Publish / Prepare") job used `if: always()`, so on pull requests — where the upstream `release` job is skipped and emits empty-string outputs — the guard `versions != '{}'` evaluated true and the job still spun up a runner to produce empty lists. Adding `needs.release.result == 'success'` makes Prepare skip whenever `release` did not actually run (PRs, merge_group, non-default branches), while the existing `versions != '{}'` clause still covers the "nothing to release" case. Downstream publish jobs are unaffected since they already gate on `has-released-*` outputs.