### PR TITLE
feat(action-tool-installer): shared binary-fetching package

### DIFF
--- a/actions/setup-k8s-tools/src/main.ts
+++ b/actions/setup-k8s-tools/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core";
 import { getOctokit } from "@actions/github";
+import { installTool } from "@internal/action-tool-installer";
 
-import { installTool } from "./install.js";
 import { TOOLS } from "./tools.js";
 
 (async () => {
@@ -11,7 +11,11 @@ import { TOOLS } from "./tools.js";
 	// Install all enabled tools.
 	await Promise.all(
 		TOOLS.map((tool) =>
-			installTool(tool, core.getInput(tool.name), { octokit, token }),
+			installTool(tool, core.getInput(tool.name), {
+				octokit,
+				token,
+				namespace: "setup-k8s-tools",
+			}),
 		),
 	);
 })().catch((error: unknown) => {

--- a/actions/setup-k8s-tools/src/tools.ts
+++ b/actions/setup-k8s-tools/src/tools.ts
@@ -1,25 +1,13 @@
-import { resolveLatestTagCached } from "./latest-tag-cache.js";
+import { resolveLatestTagCached } from "@internal/action-tool-installer";
 
-import type { getOctokit } from "@actions/github";
+import type {
+	OctokitType,
+	ToolConfig,
+	ToolResolution,
+	ResolveContext,
+} from "@internal/action-tool-installer";
 
-export type OctokitType = ReturnType<typeof getOctokit>;
-
-export interface ToolResolution {
-	version: string;
-	downloadUrl: string;
-}
-
-export interface ResolveContext {
-	octokit: OctokitType;
-	platform: string;
-	arch: string;
-}
-
-export interface ToolConfig {
-	name: string;
-	archiveType: "tar" | "zip" | "binary";
-	resolve: (input: string, ctx: ResolveContext) => Promise<ToolResolution>;
-}
+export type { OctokitType, ToolConfig, ToolResolution, ResolveContext };
 
 export const TOOLS: ToolConfig[] = [
 	{
@@ -32,6 +20,7 @@ export const TOOLS: ToolConfig[] = [
 							cacheId: "kube-score",
 							owner: "zegl",
 							repo: "kube-score",
+							namespace: "setup-k8s-tools",
 						})
 					: input;
 
@@ -52,6 +41,7 @@ export const TOOLS: ToolConfig[] = [
 							cacheId: "kubeconform",
 							owner: "yannh",
 							repo: "kubeconform",
+							namespace: "setup-k8s-tools",
 						})
 					: input;
 
@@ -71,6 +61,7 @@ export const TOOLS: ToolConfig[] = [
 							cacheId: "kustomize",
 							owner: "kubernetes-sigs",
 							repo: "kustomize",
+							namespace: "setup-k8s-tools",
 							tagFilter: (tag) => tag.startsWith("kustomize/v"),
 						})
 					: `kustomize/${input}`;
@@ -92,6 +83,7 @@ export const TOOLS: ToolConfig[] = [
 							cacheId: "argocd",
 							owner: "argoproj",
 							repo: "argo-cd",
+							namespace: "setup-k8s-tools",
 						})
 					: input;
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 	},
 	"workspaces": [
 		"actions/*",
-		"workflows/*"
+		"workflows/*",
+		"packages/*"
 	],
 	"scripts": {
 		"build": "turbo build",
@@ -21,8 +22,8 @@
 		"format:fix": "prettier --ignore-path .gitignore --write '{*,.github/**/*}.{json,json5,yaml,yml,md}'",
 		"postinstall": "husky install",
 		"readme:generate": "tsx scripts/generate-readme.ts && yarn turbo format:fix",
-		"sort:check": "sort-package-json '{actions,workflows}/**!(node_modules)/package.json' 'package.json' --check",
-		"sort:fix": "sort-package-json '{actions,workflows}/**!(node_modules)/package.json' 'package.json'"
+		"sort:check": "sort-package-json '{actions,workflows,packages}/**!(node_modules)/package.json' 'package.json' --check",
+		"sort:fix": "sort-package-json '{actions,workflows,packages}/**!(node_modules)/package.json' 'package.json'"
 	},
 	"commitlint": {
 		"extends": [

--- a/packages/action-tool-installer/eslint.config.ts
+++ b/packages/action-tool-installer/eslint.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "eslint/config";
+import { base, configFiles } from "@abinnovision/eslint-config-base";
+
+export default defineConfig([
+	{ extends: [base] },
+	{ files: ["*.{c,m,}{t,j}s"], extends: [configFiles] },
+]);

--- a/packages/action-tool-installer/package.json
+++ b/packages/action-tool-installer/package.json
@@ -1,6 +1,7 @@
 {
-	"name": "setup-k8s-tools",
-	"version": "1.1.1",
+	"name": "@internal/action-tool-installer",
+	"version": "1.0.0",
+	"private": true,
 	"license": "Apache-2.0",
 	"author": {
 		"name": "abi group GmbH",
@@ -8,16 +9,19 @@
 		"url": "https://abigroup.io/"
 	},
 	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"files": [
-		"dist",
-		"README.md",
-		"CHANGELOG.md",
-		"LICENSE.md",
-		"action.yml"
+		"dist"
 	],
 	"scripts": {
-		"build": "ncc build src/main.ts",
-		"build:watch": "ncc build --watch src/main.ts",
+		"build": "tsc -p tsconfig.json",
 		"format:check": "prettier --check 'src/**/*.{ts,js}' '*.{md,json,json5,yaml,yml}'",
 		"format:fix": "prettier --write 'src/**/*.{ts,js}' '*.{md,json,json5,yaml,yml}'",
 		"lint:check": "eslint 'src/**/*.{ts,js}'",
@@ -34,14 +38,14 @@
 	},
 	"prettier": "@abinnovision/prettier-config",
 	"dependencies": {
+		"@actions/cache": "^6.1.0",
 		"@actions/core": "^3.0.1",
 		"@actions/github": "^9.1.1",
-		"@internal/action-tool-installer": "workspace:^"
+		"@actions/tool-cache": "^4.0.0"
 	},
 	"devDependencies": {
 		"@abinnovision/eslint-config-base": "^3.4.0",
 		"@abinnovision/prettier-config": "^2.2.0",
-		"@vercel/ncc": "^0.44.1",
 		"eslint": "^10.2.1",
 		"prettier": "^3.8.3",
 		"typescript": "^6.0.3"

--- a/packages/action-tool-installer/src/index.ts
+++ b/packages/action-tool-installer/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./install.js";
+export * from "./latest-tag-cache.js";
+export * from "./tools.js";

--- a/packages/action-tool-installer/src/install.ts
+++ b/packages/action-tool-installer/src/install.ts
@@ -10,6 +10,7 @@ import type { OctokitType, ToolConfig } from "./tools.js";
 interface InstallContext {
 	octokit: OctokitType;
 	token: string;
+	namespace: string;
 }
 
 const mapPlatform = (platform: string): string => {
@@ -60,10 +61,10 @@ export const installTool = async (
 	}
 
 	// Layer 2: actions cache - persists across runs on all runner types.
-	const cacheKey = `setup-k8s-tools-${config.name}-${version}-${platform}-${arch}`;
+	const cacheKey = `${ctx.namespace}-${config.name}-${version}-${platform}-${arch}`;
 	const restorePath = path.join(
 		process.env["RUNNER_TEMP"] ?? os.tmpdir(),
-		"setup-k8s-tools",
+		ctx.namespace,
 		config.name,
 		version,
 	);
@@ -108,9 +109,15 @@ export const installTool = async (
 	try {
 		await cache.saveCache([restorePath], cacheKey);
 	} catch (err) {
-		core.warning(
-			err instanceof Error ? err.message : "Failed to save to actions cache",
-		);
+		if (err instanceof cache.CacheWriteDeniedError) {
+			core.info(
+				`Skipped caching ${config.name} ${version}: actions cache is read-only for this trigger`,
+			);
+		} else {
+			core.warning(
+				err instanceof Error ? err.message : "Failed to save to actions cache",
+			);
+		}
 	}
 
 	await activate(restorePath);

--- a/packages/action-tool-installer/src/latest-tag-cache.ts
+++ b/packages/action-tool-installer/src/latest-tag-cache.ts
@@ -6,12 +6,11 @@ import * as path from "node:path";
 
 import type { OctokitType } from "./tools.js";
 
-const CACHE_KEY_PREFIX = "setup-k8s-tools-latest";
-
 interface ResolveLatestTagInput {
 	cacheId: string;
 	owner: string;
 	repo: string;
+	namespace: string;
 	tagFilter?: (tag: string) => boolean;
 }
 
@@ -36,10 +35,10 @@ const resolveLatestTagFresh = async (
 // UTC date bucket → cache rotates at most once per day.
 const computeBucket = (): string => new Date().toISOString().slice(0, 10);
 
-const buildCacheFilePath = (cacheId: string): string =>
+const buildCacheFilePath = (namespace: string, cacheId: string): string =>
 	path.join(
 		process.env["RUNNER_TEMP"] ?? os.tmpdir(),
-		"setup-k8s-tools",
+		namespace,
 		"latest",
 		`${cacheId}.json`,
 	);
@@ -49,9 +48,10 @@ const resolveLatestTagCached = async (
 	input: ResolveLatestTagInput,
 ): Promise<string> => {
 	const bucket = computeBucket();
-	const primaryKey = `${CACHE_KEY_PREFIX}-${input.cacheId}-${bucket}`;
-	const restorePrefix = `${CACHE_KEY_PREFIX}-${input.cacheId}-`;
-	const filePath = buildCacheFilePath(input.cacheId);
+	const cacheKeyPrefix = `${input.namespace}-latest`;
+	const primaryKey = `${cacheKeyPrefix}-${input.cacheId}-${bucket}`;
+	const restorePrefix = `${cacheKeyPrefix}-${input.cacheId}-`;
+	const filePath = buildCacheFilePath(input.namespace, input.cacheId);
 
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 
@@ -84,11 +84,17 @@ const resolveLatestTagCached = async (
 		);
 		await cache.saveCache([filePath], primaryKey);
 	} catch (err) {
-		core.warning(
-			err instanceof Error
-				? `Failed to save latest-tag cache for ${input.cacheId}: ${err.message}`
-				: `Failed to save latest-tag cache for ${input.cacheId}`,
-		);
+		if (err instanceof cache.CacheWriteDeniedError) {
+			core.info(
+				`Skipped caching latest tag for ${input.cacheId}: actions cache is read-only for this trigger`,
+			);
+		} else {
+			core.warning(
+				err instanceof Error
+					? `Failed to save latest-tag cache for ${input.cacheId}: ${err.message}`
+					: `Failed to save latest-tag cache for ${input.cacheId}`,
+			);
+		}
 	}
 
 	return tag;

--- a/packages/action-tool-installer/src/tools.ts
+++ b/packages/action-tool-installer/src/tools.ts
@@ -1,0 +1,20 @@
+import type { getOctokit } from "@actions/github";
+
+export type OctokitType = ReturnType<typeof getOctokit>;
+
+export interface ToolResolution {
+	version: string;
+	downloadUrl: string;
+}
+
+export interface ResolveContext {
+	octokit: OctokitType;
+	platform: string;
+	arch: string;
+}
+
+export interface ToolConfig {
+	name: string;
+	archiveType: "tar" | "zip" | "binary";
+	resolve: (input: string, ctx: ResolveContext) => Promise<ToolResolution>;
+}

--- a/packages/action-tool-installer/tsconfig.json
+++ b/packages/action-tool-installer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"noEmit": false,
+		"outDir": "./dist",
+		"declaration": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -19,9 +19,11 @@
 			"cache": false
 		},
 		"lint:fix": {
+			"dependsOn": ["^build"],
 			"cache": false
 		},
 		"lint:check": {
+			"dependsOn": ["^build"],
 			"cache": false
 		}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@internal/action-tool-installer@workspace:^, @internal/action-tool-installer@workspace:packages/action-tool-installer":
+  version: 0.0.0-use.local
+  resolution: "@internal/action-tool-installer@workspace:packages/action-tool-installer"
+  dependencies:
+    "@abinnovision/eslint-config-base": "npm:^3.4.0"
+    "@abinnovision/prettier-config": "npm:^2.2.0"
+    "@actions/cache": "npm:^6.1.0"
+    "@actions/core": "npm:^3.0.1"
+    "@actions/github": "npm:^9.1.1"
+    "@actions/tool-cache": "npm:^4.0.0"
+    eslint: "npm:^10.2.1"
+    prettier: "npm:^3.8.3"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
@@ -4269,10 +4285,9 @@ __metadata:
   dependencies:
     "@abinnovision/eslint-config-base": "npm:^3.4.0"
     "@abinnovision/prettier-config": "npm:^2.2.0"
-    "@actions/cache": "npm:^6.1.0"
     "@actions/core": "npm:^3.0.1"
     "@actions/github": "npm:^9.1.1"
-    "@actions/tool-cache": "npm:^4.0.0"
+    "@internal/action-tool-installer": "workspace:^"
     "@vercel/ncc": "npm:^0.44.1"
     eslint: "npm:^10.2.1"
     prettier: "npm:^3.8.3"


### PR DESCRIPTION
Extracts the generic download/extract/cache engine from `setup-k8s-tools` into a new internal `@internal/action-tool-installer` workspace package (the repo's first `packages/*` workspace and first `workspace:` dependency) so future CLI installers like `oidc-token-cli` can reuse it. The engine is parameterized with a cache `namespace` (preserving `setup-k8s-tools`' existing cache keys), and `setup-k8s-tools` now consumes the package via `workspace:^`, supplying only its tool config. Save failures caused by a read-only actions cache on untrusted triggers are detected via `CacheWriteDeniedError` and logged quietly instead of as warnings. Root config adds `packages/*` to workspaces and the package-sort globs. Verified with `yarn build` and `yarn check` (18/18).