### PR TITLE
fix(tsconfig): remove rootDir from base config

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"rootDir": "./src",
 		"strict": true,
 		"target": "es2022",
 		"module": "Node16",


### PR DESCRIPTION
The `rootDir: "./src"` in `tsconfig.base.json` was inert there (the base is `noEmit`) but, through `extends`, resolved to `<repo-root>/src` for every consumer that didn't override it — since relative `compilerOptions` paths resolve against the file that defines them. That triggered `TS6059 (... is not under rootDir)` in IntelliJ/tsc for files under each package's own `src`. Removing the line lets consumers infer `rootDir` from their own included files, clearing the error. The only emitting project, `action-tool-installer`, keeps its own `rootDir`, so its `dist` output is unaffected (verified: build passes, layout unchanged under TS 6.0.3).