### PR TITLE
fix(tsconfig): set rootDir per package to match source layout

### DIFF
--- a/actions/run-commitlint/tsconfig.json
+++ b/actions/run-commitlint/tsconfig.json
@@ -1,4 +1,7 @@
 {
 	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src"
+	},
 	"include": ["src/**/*.ts", "shims.d.ts"]
 }

--- a/actions/run-release-please/tsconfig.json
+++ b/actions/run-release-please/tsconfig.json
@@ -1,4 +1,7 @@
 {
 	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src"
+	},
 	"include": ["src/**/*.ts", "shims.d.ts"]
 }

--- a/actions/setup-k8s-tools/tsconfig.json
+++ b/actions/setup-k8s-tools/tsconfig.json
@@ -1,4 +1,7 @@
 {
 	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src"
+	},
 	"include": ["src/**/*.ts"]
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
+		"rootDir": ".",
 		"noEmit": true
 	},
 	"include": ["**/*.ts"]


### PR DESCRIPTION
Restores an explicit `rootDir` in each TypeScript package after it was removed from `tsconfig.base.json` in #449, where a single shared value no longer fit every package. The three `src/`-based actions (`run-commitlint`, `run-release-please`, `setup-k8s-tools`) get `rootDir: "./src"`, while `scripts` (flat layout) gets `rootDir: "."`. `action-tool-installer` already declared it correctly and is unchanged. Verified with `yarn build` and per-package `tsc --noEmit` — no errors and no TS6059 "not under rootDir" issues.

BEGIN_COMMIT_OVERRIDE
build(tsconfig): set rootDir per package to match source layout
END_COMMIT_OVERRIDE