### PR TITLE
feat(action-tool-installer): return resolved version from installTool

### DIFF
--- a/packages/action-tool-installer/src/install.ts
+++ b/packages/action-tool-installer/src/install.ts
@@ -36,10 +36,10 @@ export const installTool = async (
 	config: ToolConfig,
 	input: string,
 	ctx: InstallContext,
-): Promise<void> => {
+): Promise<string | undefined> => {
 	if (!input) {
 		core.setOutput(`${config.name}-version`, "");
-		return;
+		return undefined;
 	}
 
 	const platform = mapPlatform(process.platform);
@@ -57,7 +57,7 @@ export const installTool = async (
 		core.info(`${config.name} ${version} restored from tool cache`);
 		core.addPath(tcPath);
 		core.setOutput(`${config.name}-version`, version);
-		return;
+		return version;
 	}
 
 	// Layer 2: actions cache - persists across runs on all runner types.
@@ -79,7 +79,7 @@ export const installTool = async (
 	if (restoredKey) {
 		core.info(`${config.name} ${version} restored from actions cache`);
 		await activate(restorePath);
-		return;
+		return version;
 	}
 
 	// Download and materialize into restorePath, then populate both cache layers.
@@ -122,4 +122,5 @@ export const installTool = async (
 
 	await activate(restorePath);
 	core.info(`${config.name} ${version} installed`);
+	return version;
 };


### PR DESCRIPTION
`installTool` now returns the resolved tool version (`Promise<string | undefined>`) instead of `Promise<void>`, so callers can consume it directly. It returns the version on every install path (tool-cache hit, actions-cache hit, and fresh download) and `undefined` when input is empty and nothing is installed. The existing `core.setOutput` / `core.addPath` side effects and the `${name}-version` action output are unchanged, so this is backward compatible.