### PR TITLE
fix(exchange-github-token): add missing .prettierignore

### DIFF
--- a/actions/exchange-github-token/.prettierignore
+++ b/actions/exchange-github-token/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
Adds the missing `.prettierignore` file with `CHANGELOG.md` to the `exchange-github-token` action. All other releasable packages already had this file to prevent Prettier from reformatting the auto-generated changelog.