### PR TITLE
revert: failed release (#454), fix setup-k8s-tools dependency

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"actions/exchange-github-token": "1.1.0",
+	"actions/exchange-github-token": "1.0.0",
 	"actions/run-commitlint": "1.3.1",
 	"actions/run-release-please": "1.1.4",
 	"actions/setup-gcp": "1.1.1",
@@ -7,8 +7,8 @@
 	"actions/setup-k8s-tools": "2.0.0",
 	"actions/setup-oidc-token-cli": "1.1.0",
 	"actions/setup-tools": "1.0.2",
-	"workflows/release": "2.1.0",
+	"workflows/release": "2.0.2",
 	"workflows/gitops-deploy": "1.0.8",
-	"workflows/gitops-update-tags": "1.2.0",
-	"workflows/polyglot-monorepo-stack": "1.5.0"
+	"workflows/gitops-update-tags": "1.1.5",
+	"workflows/polyglot-monorepo-stack": "1.4.2"
 }

--- a/actions/exchange-github-token/CHANGELOG.md
+++ b/actions/exchange-github-token/CHANGELOG.md
@@ -1,15 +1,1 @@
 # Changelog
-
-## [1.1.0](https://github.com/abinnovision/actions/compare/exchange-github-token-source-v1.0.0...exchange-github-token-source-v1.1.0) (2026-07-19)
-
-
-### Features
-
-* **exchange-github-token:** add OIDC token exchange action, remove deprecated actions ([#453](https://github.com/abinnovision/actions/issues/453)) ([d7c6155](https://github.com/abinnovision/actions/commit/d7c6155a11f312d9923e6a245a167099e942f0df))
-
-
-### Bug Fixes
-
-* **exchange-github-token:** add missing .prettierignore ([#457](https://github.com/abinnovision/actions/issues/457)) ([f6d38d9](https://github.com/abinnovision/actions/commit/f6d38d9084184d99f82b6212f1c47df348d45171))
-
-## Changelog

--- a/actions/exchange-github-token/README.md
+++ b/actions/exchange-github-token/README.md
@@ -41,7 +41,7 @@ steps:
 This action can be used with different version ranges. The following ranges are available:
 
 - `abinnovision/actions@exchange-github-token-v1`: Targeting major version <!-- x-release-please-major -->
-- `abinnovision/actions@exchange-github-token-v1.1.0`: Targeting a patch version <!-- x-release-please-version -->
+- `abinnovision/actions@exchange-github-token-v1.0.0`: Targeting a patch version <!-- x-release-please-version -->
 
 ## Inputs
 

--- a/actions/exchange-github-token/package.json
+++ b/actions/exchange-github-token/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "exchange-github-token",
-	"version": "1.1.0",
+	"version": "1.0.0",
 	"license": "Apache-2.0",
 	"author": {
 		"name": "abi group GmbH",

--- a/workflows/gitops-update-tags/CHANGELOG.md
+++ b/workflows/gitops-update-tags/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [1.2.0](https://github.com/abinnovision/actions/compare/gitops-update-tags-source-v1.1.5...gitops-update-tags-source-v1.2.0) (2026-07-19)
-
-
-### Features
-
-* **exchange-github-token:** add OIDC token exchange action, remove deprecated actions ([#453](https://github.com/abinnovision/actions/issues/453)) ([d7c6155](https://github.com/abinnovision/actions/commit/d7c6155a11f312d9923e6a245a167099e942f0df))
-* use token broker ([#456](https://github.com/abinnovision/actions/issues/456)) ([a8dc1ac](https://github.com/abinnovision/actions/commit/a8dc1ace2551c90fa1b258ae0e75fc0e616bf95e))
-
 ## [1.1.5](https://github.com/abinnovision/actions/compare/gitops-update-tags-source-v1.1.4...gitops-update-tags-source-v1.1.5) (2026-07-09)
 
 

--- a/workflows/gitops-update-tags/README.md
+++ b/workflows/gitops-update-tags/README.md
@@ -31,7 +31,7 @@ jobs:
 This workflow can be used with different version ranges. The following ranges are available:
 
 - `abinnovision/actions/.github/workflows/workflow.yaml@gitops-update-tags-v1`: Targeting major version <!-- x-release-please-major -->
-- `abinnovision/actions/.github/workflows/workflow.yaml@gitops-update-tags-v1.2.0`: Targeting a patch version <!-- x-release-please-version -->
+- `abinnovision/actions/.github/workflows/workflow.yaml@gitops-update-tags-v1.1.5`: Targeting a patch version <!-- x-release-please-version -->
 
 ## Advanced Configuration
 

--- a/workflows/gitops-update-tags/package.json
+++ b/workflows/gitops-update-tags/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gitops-update-tags",
-	"version": "1.2.0",
+	"version": "1.1.5",
 	"license": "Apache-2.0",
 	"author": {
 		"name": "abi group GmbH",

--- a/workflows/gitops-update-tags/package.json
+++ b/workflows/gitops-update-tags/package.json
@@ -30,7 +30,7 @@
 	"actionDependencies": {
 		"exchange-github-token": "^1.0.0",
 		"setup-gcp": "^1.0.0",
-		"setup-k8s-tools": "^1.0.0",
+		"setup-k8s-tools": "^2.0.0",
 		"setup-node": "^1.0.0"
 	}
 }

--- a/workflows/polyglot-monorepo-stack/CHANGELOG.md
+++ b/workflows/polyglot-monorepo-stack/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [1.5.0](https://github.com/abinnovision/actions/compare/polyglot-monorepo-stack-source-v1.4.2...polyglot-monorepo-stack-source-v1.5.0) (2026-07-19)
-
-
-### Features
-
-* **exchange-github-token:** add OIDC token exchange action, remove deprecated actions ([#453](https://github.com/abinnovision/actions/issues/453)) ([d7c6155](https://github.com/abinnovision/actions/commit/d7c6155a11f312d9923e6a245a167099e942f0df))
-* use token broker ([#456](https://github.com/abinnovision/actions/issues/456)) ([a8dc1ac](https://github.com/abinnovision/actions/commit/a8dc1ace2551c90fa1b258ae0e75fc0e616bf95e))
-
 ## [1.4.2](https://github.com/abinnovision/actions/compare/polyglot-monorepo-stack-source-v1.4.1...polyglot-monorepo-stack-source-v1.4.2) (2026-07-15)
 
 

--- a/workflows/polyglot-monorepo-stack/README.md
+++ b/workflows/polyglot-monorepo-stack/README.md
@@ -394,7 +394,7 @@ jobs:
 This workflow can be used with different version ranges. The following ranges are available:
 
 - `abinnovision/actions/.github/workflows/workflow.yaml@polyglot-monorepo-stack-v1`: Targeting major version <!-- x-release-please-major -->
-- `abinnovision/actions/.github/workflows/workflow.yaml@polyglot-monorepo-stack-v1.5.0`: Targeting a patch version <!-- x-release-please-version -->
+- `abinnovision/actions/.github/workflows/workflow.yaml@polyglot-monorepo-stack-v1.4.2`: Targeting a patch version <!-- x-release-please-version -->
 
 ## Inputs
 

--- a/workflows/polyglot-monorepo-stack/package.json
+++ b/workflows/polyglot-monorepo-stack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "polyglot-monorepo-stack",
-	"version": "1.5.0",
+	"version": "1.4.2",
 	"license": "Apache-2.0",
 	"author": {
 		"name": "abi group GmbH",

--- a/workflows/release/CHANGELOG.md
+++ b/workflows/release/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [2.1.0](https://github.com/abinnovision/actions/compare/release-source-v2.0.2...release-source-v2.1.0) (2026-07-19)
-
-
-### Features
-
-* **exchange-github-token:** add OIDC token exchange action, remove deprecated actions ([#453](https://github.com/abinnovision/actions/issues/453)) ([d7c6155](https://github.com/abinnovision/actions/commit/d7c6155a11f312d9923e6a245a167099e942f0df))
-* use token broker ([#456](https://github.com/abinnovision/actions/issues/456)) ([a8dc1ac](https://github.com/abinnovision/actions/commit/a8dc1ace2551c90fa1b258ae0e75fc0e616bf95e))
-
 ## [2.0.2](https://github.com/abinnovision/actions/compare/release-source-v2.0.1...release-source-v2.0.2) (2026-02-22)
 
 

--- a/workflows/release/README.md
+++ b/workflows/release/README.md
@@ -19,7 +19,7 @@ jobs:
 This workflow can be used with different version ranges. The following ranges are available:
 
 - `abinnovision/actions/.github/workflows/workflow.yaml@release-v2`: Targeting major version <!-- x-release-please-major -->
-- `abinnovision/actions/.github/workflows/workflow.yaml@release-v2.1.0`: Targeting a patch version <!-- x-release-please-version -->
+- `abinnovision/actions/.github/workflows/workflow.yaml@release-v2.0.2`: Targeting a patch version <!-- x-release-please-version -->
 
 ## Inputs
 

--- a/workflows/release/package.json
+++ b/workflows/release/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "release",
-	"version": "2.1.0",
+	"version": "2.0.2",
 	"license": "Apache-2.0",
 	"author": {
 		"name": "abi group GmbH",


### PR DESCRIPTION
## Summary

- Reverts release commit `6b67218` ("chore: release main (#454)") which failed during Publish due to a `setup-k8s-tools` version mismatch
- Fixes the root cause: bumps `setup-k8s-tools` actionDependency from `^1.0.0` to `^2.0.0` in `workflows/gitops-update-tags/package.json`
- Deleted orphaned tags from the partial publish: `exchange-github-token-source-v1.1.0`, `exchange-github-token-v1.1.0`, `exchange-github-token-v1.1`, `release-source-v2.1.0`, `release-v2.1.0`, `release-v2.1`

> **Note:** The branches `action/exchange-github-token/v1.1.0` and `workflow/release/v2.1.0` are protected by repository rules and could not be deleted via API. They should be removed manually or via repo admin settings.

## Context

The Publish job in [run #29692650548](https://github.com/abinnovision/actions/actions/runs/29692650548/job/88208115950) failed with:
```
Error: actionDependency 'setup-k8s-tools' declares range '^1.0.0' but workspace version is 2.0.0 (major version mismatch).
```

Two packages (`exchange-github-token` v1.1.0, `workflows/release` v2.1.0) were published before the failure. Their tags have been cleaned up so the next release is consistent.