### PR TITLE
fix(exchange-github-token): fall back audience to broker URL

### DIFF
--- a/actions/exchange-github-token/README.md
+++ b/actions/exchange-github-token/README.md
@@ -48,7 +48,7 @@ This action can be used with different version ranges. The following ranges are 
 | Input                    | Description                                                                           | Required | Default               |
 | :----------------------- | :------------------------------------------------------------------------------------ | :------- | :-------------------- |
 | `broker-url`             | Base URL of the token broker service (used as OIDC issuer for discovery)              | Yes      |                       |
-| `audience`               | OIDC audience for the token broker (defaults to 'gh-token-broker')                    | No       | `gh-token-broker`     |
+| `audience`               | OIDC audience for the token broker (defaults to broker-url)                           | No       | _empty_               |
 | `scope`                  | Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)     | No       | _empty_               |
 | `repositories`           | Repositories the token should access, whitespace-separated (defaults to current repo) | No       | _empty_               |
 | `github-token`           | Token for downloading oidc-token-cli from GitHub releases                             | No       | `${{ github.token }}` |

--- a/actions/exchange-github-token/action.yml
+++ b/actions/exchange-github-token/action.yml
@@ -6,9 +6,8 @@ inputs:
     description: "Base URL of the token broker service (used as OIDC issuer for discovery)"
     required: true
   audience:
-    description: "OIDC audience for the token broker (defaults to 'gh-token-broker')"
+    description: "OIDC audience for the token broker (defaults to broker-url)"
     required: false
-    default: "gh-token-broker"
   scope:
     description: "Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)"
     required: false
@@ -59,7 +58,7 @@ runs:
           --client-id gh-token-broker
           --grant-type token-exchange
           --subject-token-source github-actions
-          --audience "$AUDIENCE"
+          --audience "${AUDIENCE:-$BROKER_URL}"
         )
 
         # Add scope (whitespace-separated scope:level tokens)


### PR DESCRIPTION
## Summary

- Remove the hardcoded `gh-token-broker` default for the `audience` input
- Fall back to the broker URL (which is also the OIDC issuer) when no audience is provided, using `${AUDIENCE:-$BROKER_URL}` in the shell script