### PR TITLE
fix: exclude draft and pre-release when resolving latest version

### DIFF
--- a/actions/setup-k8s-tools/src/tools.ts
+++ b/actions/setup-k8s-tools/src/tools.ts
@@ -19,7 +19,12 @@ export const TOOLS: ToolConfig[] = [
 		async resolve(input, { octokit, platform, arch }) {
 			const owner = "zegl";
 			const repo = "kube-score";
-			const version = await resolveVersion(octokit, input, { owner, repo });
+			const version = await resolveVersion(octokit, input, {
+				owner,
+				repo,
+				excludeDrafts: true,
+				excludePreReleases: true,
+			});
 
 			const tag = `v${version}`;
 			return {
@@ -39,7 +44,12 @@ export const TOOLS: ToolConfig[] = [
 		async resolve(input, { octokit, platform, arch }) {
 			const owner = "yannh";
 			const repo = "kubeconform";
-			const version = await resolveVersion(octokit, input, { owner, repo });
+			const version = await resolveVersion(octokit, input, {
+				owner,
+				repo,
+				excludeDrafts: true,
+				excludePreReleases: true,
+			});
 
 			const tag = `v${version}`;
 			return {
@@ -62,6 +72,8 @@ export const TOOLS: ToolConfig[] = [
 			const version = await resolveVersion(octokit, input, {
 				owner,
 				repo,
+				excludeDrafts: true,
+				excludePreReleases: true,
 				tagFilter: (tag) => tag.startsWith("kustomize/v"),
 				fromTag: (tag) => tag.replace(/^kustomize\/v/, ""),
 			});
@@ -84,7 +96,12 @@ export const TOOLS: ToolConfig[] = [
 		async resolve(input, { octokit, platform, arch }) {
 			const owner = "argoproj";
 			const repo = "argo-cd";
-			const version = await resolveVersion(octokit, input, { owner, repo });
+			const version = await resolveVersion(octokit, input, {
+				owner,
+				repo,
+				excludeDrafts: true,
+				excludePreReleases: true,
+			});
 
 			const tag = `v${version}`;
 			const suffix = platform === "windows" ? ".exe" : "";

--- a/actions/setup-oidc-token-cli/src/tools.ts
+++ b/actions/setup-oidc-token-cli/src/tools.ts
@@ -18,7 +18,12 @@ export const TOOL: ToolConfig = {
 	async resolve(input, { octokit, platform, arch }) {
 		const owner = "abinnovision";
 		const repo = "oidc-token-cli";
-		const version = await resolveVersion(octokit, input, { owner, repo });
+		const version = await resolveVersion(octokit, input, {
+			owner,
+			repo,
+			excludeDrafts: true,
+			excludePreReleases: true,
+		});
 
 		const tag = `v${version}`;
 		return {

--- a/packages/action-tool-installer/src/resolve-version.ts
+++ b/packages/action-tool-installer/src/resolve-version.ts
@@ -5,6 +5,8 @@ import type { OctokitType } from "./tools.js";
 interface ResolveLatestTagInput {
 	owner: string;
 	repo: string;
+	excludeDrafts: boolean;
+	excludePreReleases: boolean;
 	tagFilter?: (tag: string) => boolean;
 }
 
@@ -19,7 +21,10 @@ const resolveLatestTag = async (
 	});
 
 	const release = data.find(
-		(r) => !r.draft && !r.prerelease && (input.tagFilter?.(r.tag_name) ?? true),
+		(r) =>
+			(!input.excludeDrafts || !r.draft) &&
+			(!input.excludePreReleases || !r.prerelease) &&
+			(input.tagFilter?.(r.tag_name) ?? true),
 	);
 	if (release) {
 		return release.tag_name;
@@ -31,6 +36,8 @@ const resolveLatestTag = async (
 export interface ResolveVersionOptions {
 	owner: string;
 	repo: string;
+	excludeDrafts?: boolean;
+	excludePreReleases?: boolean;
 	tagFilter?: (tag: string) => boolean;
 	// Extracts the bare semver (e.g. "1.2.3") from a concrete git tag when
 	// resolving "latest". Defaults to stripping a leading "v".
@@ -46,6 +53,8 @@ export const resolveVersion = async (
 		const tag = await resolveLatestTag(octokit, {
 			owner: options.owner,
 			repo: options.repo,
+			excludeDrafts: options.excludeDrafts ?? true,
+			excludePreReleases: options.excludePreReleases ?? true,
 			tagFilter: options.tagFilter,
 		});
 

--- a/packages/action-tool-installer/src/resolve-version.ts
+++ b/packages/action-tool-installer/src/resolve-version.ts
@@ -18,7 +18,9 @@ const resolveLatestTag = async (
 		per_page: 50,
 	});
 
-	const release = data.find((r) => input.tagFilter?.(r.tag_name) ?? true);
+	const release = data.find(
+		(r) => !r.draft && !r.prerelease && (input.tagFilter?.(r.tag_name) ?? true),
+	);
 	if (release) {
 		return release.tag_name;
 	}


### PR DESCRIPTION
The `resolveLatestTag` function used by all tool installer actions (oidc-token-cli, k8s-tools, etc.) did not filter out draft or pre-release GitHub releases. This meant a draft release with no uploaded assets, or an unstable pre-release, could be selected as the "latest" version. This adds `!r.draft && !r.prerelease` checks to the `.find()` predicate so only stable, published releases are considered.