### PR TITLE
feat: add node-workspace plugin for internal package version propagation

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,6 @@
 	"workflows/release": "2.1.1",
 	"workflows/gitops-deploy": "1.0.9",
 	"workflows/gitops-update-tags": "1.2.1",
-	"workflows/polyglot-monorepo-stack": "1.5.1"
+	"workflows/polyglot-monorepo-stack": "1.5.1",
+	"packages/action-tool-installer": "1.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
 	"changelog-path": "CHANGELOG.md",
 	"release-type": "node",
 	"tag-separator": "-source-",
+	"plugins": [{ "type": "node-workspace" }],
 	"packages": {
 		"actions/exchange-github-token": {
 			"extra-files": ["README.md"]
@@ -39,6 +40,9 @@
 		},
 		"workflows/polyglot-monorepo-stack": {
 			"extra-files": ["README.md"]
+		},
+		"packages/action-tool-installer": {
+			"skip-github-release": true
 		}
 	}
 }


### PR DESCRIPTION
Enables the release-please `node-workspace` plugin so that changes to `packages/action-tool-installer` automatically trigger patch bumps in its consumers (`setup-k8s-tools` and `setup-oidc-token-cli`).

Registers `action-tool-installer` in the release-please config with `skip-github-release: true` since it's a private internal package that doesn't need its own release or tag.