### PR TITLE
fix: pass scope and repositories to exchange-github-token in workflows

### DIFF
--- a/workflows/gitops-update-tags/workflow.yaml
+++ b/workflows/gitops-update-tags/workflow.yaml
@@ -86,6 +86,8 @@ jobs:
         uses: abinnovision/actions@exchange-github-token-dev
         with:
           broker-url: ${{ inputs.token-broker-url || vars.TOKEN_BROKER_URL }}
+          scope: contents:write pull_requests:write
+          repositories: ${{ github.repository }}
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/workflows/release/workflow.yaml
+++ b/workflows/release/workflow.yaml
@@ -61,6 +61,8 @@ jobs:
         uses: abinnovision/actions@exchange-github-token-dev
         with:
           broker-url: ${{ inputs.token-broker-url || vars.TOKEN_BROKER_URL }}
+          scope: contents:write pull_requests:write
+          repositories: ${{ github.repository }}
       - id: release
         name: Run release-please
         uses: abinnovision/actions@run-release-please-dev


### PR DESCRIPTION
## Summary

- Add required `scope` and `repositories` inputs to `exchange-github-token` calls in the Release and GitOps Update Tags workflows
- Both workflows need `contents:write pull_requests:write` on the current repository
- The Polyglot Monorepo Stack's GitOps dispatch step already had these set correctly