### PR TITLE
chore: add prettierignore to action-tool-installer

### DIFF
--- a/packages/action-tool-installer/.prettierignore
+++ b/packages/action-tool-installer/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
Adds a `.prettierignore` file to the `action-tool-installer` package, excluding `CHANGELOG.md` from Prettier formatting. This aligns the package with all other actions and packages in the repo.