### PR TITLE
fix: allow github release for action-tool-installer

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -41,8 +41,6 @@
 		"workflows/polyglot-monorepo-stack": {
 			"extra-files": ["README.md"]
 		},
-		"packages/action-tool-installer": {
-			"skip-github-release": true
-		}
+		"packages/action-tool-installer": {}
 	}
 }


### PR DESCRIPTION
## Summary

Removes `skip-github-release: true` from the `action-tool-installer` package in release-please config. This flag prevented release-please from creating a git tag, so it kept re-proposing the same commits as new releases on every run -- causing an infinite release loop that also cascaded unnecessary dependency bumps to `setup-k8s-tools` and `setup-oidc-token-cli` via the `node-workspace` plugin.