### PR TITLE
fix: exclude packages from release publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -264,6 +264,10 @@ jobs:
           if [[ "${{ needs.release.outputs.releases-created }}" == "true" ]]; then
             echo "==> Publishing versioned releases..."
             echo '${{ needs.release.outputs.paths-released }}' | jq -cr '.[]' | while read path; do
+              if [[ "$path" == "packages/"* ]]; then
+                echo "Skipping non-publishable path: $path"
+                continue
+              fi
               publish_item "$path" "release"
             done
           else


### PR DESCRIPTION
## Summary

The publish job's release phase iterates over all paths released by release-please, which includes `packages/action-tool-installer`. Since packages are internal libraries (not git-distributed actions/workflows), they should be skipped during publish. The dev publish phase already correctly filters to only `actions/` and `workflows/` paths.

This adds a guard to skip any `packages/*` path in the release publish loop.