### PR TITLE
fix: make scope input required for exchange-github-token

### DIFF
--- a/actions/exchange-github-token/README.md
+++ b/actions/exchange-github-token/README.md
@@ -49,7 +49,7 @@ This action can be used with different version ranges. The following ranges are 
 | :----------------------- | :------------------------------------------------------------------------------------ | :------- | :-------------------- |
 | `broker-url`             | Base URL of the token broker service (used as OIDC issuer for discovery)              | Yes      |                       |
 | `audience`               | OIDC audience for the token broker (defaults to broker-url)                           | No       | _empty_               |
-| `scope`                  | Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)     | No       | _empty_               |
+| `scope`                  | Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)     | Yes      |                       |
 | `repositories`           | Repositories the token should access, whitespace-separated (defaults to current repo) | No       | _empty_               |
 | `github-token`           | Token for downloading oidc-token-cli from GitHub releases                             | No       | `${{ github.token }}` |
 | `oidc-token-cli-version` | Version of oidc-token-cli to install                                                  | No       | `latest`              |

--- a/actions/exchange-github-token/action.yml
+++ b/actions/exchange-github-token/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
   scope:
     description: "Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)"
-    required: false
+    required: true
   repositories:
     description: "Repositories the token should access, whitespace-separated (defaults to current repo)"
     required: false
@@ -62,10 +62,8 @@ runs:
         )
 
         # Add scope (whitespace-separated scope:level tokens)
-        if [ -n "$SCOPE" ]; then
-          SCOPE_VALUE=$(echo "$SCOPE" | tr '\n' ' ' | xargs)
-          ARGS+=(--scope "$SCOPE_VALUE")
-        fi
+        SCOPE_VALUE=$(echo "$SCOPE" | tr '\n' ' ' | xargs)
+        ARGS+=(--scope "$SCOPE_VALUE")
 
         # Add repositories as repeated --resource flags
         if [ -n "$REPOSITORIES" ]; then


### PR DESCRIPTION
## Summary

Makes the `scope` input required for the `exchange-github-token` action. Callers must now explicitly declare what permissions they need rather than silently getting a token with no scopes. The conditional guard around the scope argument is also removed since the value is always present.