### PR TITLE
fix: remove redundant repositories property from exchange-github-token consumers

### DIFF
--- a/workflows/gitops-update-tags/workflow.yaml
+++ b/workflows/gitops-update-tags/workflow.yaml
@@ -87,7 +87,6 @@ jobs:
         with:
           broker-url: ${{ inputs.token-broker-url || vars.TOKEN_BROKER_URL }}
           scope: contents:write pull_requests:write
-          repositories: ${{ github.repository }}
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/workflows/release/workflow.yaml
+++ b/workflows/release/workflow.yaml
@@ -62,7 +62,6 @@ jobs:
         with:
           broker-url: ${{ inputs.token-broker-url || vars.TOKEN_BROKER_URL }}
           scope: contents:write pull_requests:write
-          repositories: ${{ github.repository }}
       - id: release
         name: Run release-please
         uses: abinnovision/actions@run-release-please-dev


### PR DESCRIPTION
## Summary

- Remove the explicit `repositories: ${{ github.repository }}` from the `release` and `gitops-update-tags` workflows
- The `exchange-github-token` action already defaults to the current repository when the input is omitted, making these declarations redundant
- The `polyglot-monorepo-stack` consumer is unchanged since it targets a different repository for cross-repo GitOps dispatch