### PR TITLE
fix: prefix gitops target repo with org in polyglot workflow

### DIFF
--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -996,6 +996,9 @@ jobs:
           # Use version tag from release output directly
           deployment_tag="${{ matrix.entry.packageVersion }}"
 
+          if [[ "$target_repo" != *"/"* ]]; then
+            target_repo="${{ github.repository_owner }}/$target_repo"
+          fi
           echo "TARGET_REPO=$target_repo" >> $GITHUB_OUTPUT
           # Resolve deployment app based on release type
           if [[ "${{ matrix.entry.type }}" == "release" ]]; then


### PR DESCRIPTION
## Summary

The `exchange-github-token` action and `gh workflow run --repo` both require full `owner/repo` format for repository identifiers. When consumers provide just the repo name (e.g., `launchpad-mono-gitops`) in `gitops-app-config`, the token exchange fails because the `--resource` flag receives an unqualified name.

This adds an automatic `github.repository_owner` prefix when the parsed `target_repo` doesn't contain a `/`, making it idempotent for consumers already passing the full path.