### PR TITLE
fix: add contents:read scope to GitOps dispatch token in polyglot workflow

### DIFF
--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -1016,7 +1016,7 @@ jobs:
         with:
           broker-url: ${{ inputs.token-broker-url || vars.TOKEN_BROKER_URL }}
           repositories: ${{ steps.gitops-config.outputs.TARGET_REPO }}
-          scope: actions:write
+          scope: contents:read actions:write
 
       - name: Update GitOps Deployment (${{ steps.gitops-config.outputs.DEPLOY_APP }})
         if: inputs.gitops-app-config != '' && steps.gitops-config.outputs.TARGET_REPO != ''


### PR DESCRIPTION
## Summary

- Adds `contents:read` to the token broker scope for the GitOps dispatch token exchange in the polyglot monorepo stack workflow
- `gh workflow run` queries the target repo's default branch via GraphQL (`repository.defaultBranchRef`), which requires `contents:read` on the exchanged token
- Fixes: `unable to determine default branch for abinnovision/launchpad-mono-gitops: GraphQL: Resource not accessible by integration (repository.defaultBranchRef)`

## Test plan

- [ ] Trigger polyglot workflow on a repo with GitOps app config and verify the dispatch succeeds