### PR TITLE
feat: add triage-dependabot-prs composite action

### DIFF
--- a/.github/workflows/pr-utils.yaml
+++ b/.github/workflows/pr-utils.yaml
@@ -16,12 +16,38 @@ jobs:
       - name: Run linter
         uses: abinnovision/actions@run-commitlint-dev
   dependabot:
-    name: Dependabot automations
+    name: "Dependabot automations"
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       pull-requests: write
+      issues: write
+      repository-projects: write
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: abinnovision/actions@triage-dependabot-prs-dev
+      - id: status
+        name: Resolve current status
+        run: |
+          echo "::set-output name=HAS_REVIEWS::$(if [[ $(gh pr status --json reviews | jq '.currentBranch.reviews | length') -eq '0' ]];then echo 'false'; else echo 'true'; fi)"
+          echo "::set-output name=LAST_REVIEW_DISMISSED::$(if [[ $(gh pr status --json reviews | jq '.currentBranch.reviews[-1].state' | sed 's/"//g') -eq 'DISMISSED' ]];then echo 'true'; else echo 'false'; fi)"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-rebase
+        id: enable-auto-rebase
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: "Approve (minor & patch)"
+        id: approve
+        if: (steps.status.outputs.HAS_REVIEWS == 'false' || steps.status.outputs.LAST_REVIEW_DISMISSED == 'true') && steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-utils.yaml
+++ b/.github/workflows/pr-utils.yaml
@@ -16,38 +16,12 @@ jobs:
       - name: Run linter
         uses: abinnovision/actions@run-commitlint-dev
   dependabot:
-    name: "Dependabot automations"
+    name: Dependabot automations
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.actor == 'dependabot[bot]'
     permissions:
       pull-requests: write
-      issues: write
-      repository-projects: write
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - id: status
-        name: Resolve current status
-        run: |
-          echo "::set-output name=HAS_REVIEWS::$(if [[ $(gh pr status --json reviews | jq '.currentBranch.reviews | length') -eq '0' ]];then echo 'false'; else echo 'true'; fi)"
-          echo "::set-output name=LAST_REVIEW_DISMISSED::$(if [[ $(gh pr status --json reviews | jq '.currentBranch.reviews[-1].state' | sed 's/"//g') -eq 'DISMISSED' ]];then echo 'true'; else echo 'false'; fi)"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-rebase
-        id: enable-auto-rebase
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: "Approve (minor & patch)"
-        id: approve
-        if: (steps.status.outputs.HAS_REVIEWS == 'false' || steps.status.outputs.LAST_REVIEW_DISMISSED == 'true') && steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - uses: abinnovision/actions@triage-dependabot-prs-dev

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,6 +7,7 @@
 	"actions/setup-k8s-tools": "2.0.3",
 	"actions/setup-oidc-token-cli": "1.1.3",
 	"actions/setup-tools": "1.0.2",
+	"actions/triage-dependabot-prs": "0.0.0",
 	"workflows/release": "2.1.3",
 	"workflows/gitops-deploy": "1.0.9",
 	"workflows/gitops-update-tags": "1.2.3",

--- a/actions/triage-dependabot-prs/.prettierignore
+++ b/actions/triage-dependabot-prs/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/actions/triage-dependabot-prs/CHANGELOG.md
+++ b/actions/triage-dependabot-prs/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/triage-dependabot-prs/LICENSE.md
+++ b/actions/triage-dependabot-prs/LICENSE.md
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/actions/triage-dependabot-prs/README.md
+++ b/actions/triage-dependabot-prs/README.md
@@ -1,0 +1,59 @@
+# triage-dependabot-prs
+
+Automatically approve and enable auto-merge for Dependabot pull requests.
+By default, all update types (major, minor, patch) are auto-approved and
+auto-merged via squash.
+
+Triages Dependabot pull requests by automatically enabling auto-merge and
+approving dependency updates. The action validates its context on entry and
+skips gracefully when the actor is not `dependabot[bot]`.
+
+## Usage
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  dependabot:
+    name: Dependabot automations
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: abinnovision/actions@triage-dependabot-prs-v1
+```
+
+> **Tip:** The action includes a built-in gate that skips execution when the
+> actor is not `dependabot[bot]`. If you want to avoid spinning up the job
+> entirely, add an `if` condition to the job:
+>
+> ```yaml
+> if: ${{ github.actor == 'dependabot[bot]' }}
+> ```
+
+## Latest versions
+
+This action can be used with different version ranges. The following ranges are available:
+
+- `abinnovision/actions@triage-dependabot-prs-v0`: Targeting major version <!-- x-release-please-major -->
+- `abinnovision/actions@triage-dependabot-prs-v0.0.0`: Targeting a patch version <!-- x-release-please-version -->
+
+## Inputs
+
+| Input                  | Description                                                                                                                                                     | Required | Default               |
+| :--------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :-------------------- |
+| `token`                | GitHub token with pull-requests:write and contents:write permissions.<br>                                                                                       | No       | `${{ github.token }}` |
+| `approve-update-types` | Space-separated list of semver update types to auto-approve.<br>Supported values: major, minor, patch.<br>Auto-merge is enabled regardless of this setting.<br> | No       | `major minor patch`   |
+| `auto-merge`           | Whether to enable auto-merge on the PR.<br>                                                                                                                     | No       | `true`                |
+| `merge-method`         | Merge method to use. One of: squash, merge, rebase.<br>                                                                                                         | No       | `squash`              |
+
+## Outputs
+
+| Output        | Description                                                   |
+| :------------ | :------------------------------------------------------------ |
+| `update-type` | The semver update type detected by dependabot/fetch-metadata. |
+| `approved`    | Whether the PR was approved by this action.                   |

--- a/actions/triage-dependabot-prs/README.md
+++ b/actions/triage-dependabot-prs/README.md
@@ -19,6 +19,7 @@ jobs:
   dependabot:
     name: Dependabot automations
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       pull-requests: write
       contents: write
@@ -27,13 +28,9 @@ jobs:
       - uses: abinnovision/actions@triage-dependabot-prs-v1
 ```
 
-> **Tip:** The action includes a built-in gate that skips execution when the
-> actor is not `dependabot[bot]`. If you want to avoid spinning up the job
-> entirely, add an `if` condition to the job:
->
-> ```yaml
-> if: ${{ github.actor == 'dependabot[bot]' }}
-> ```
+> **Note:** The `if` condition is optional. The action includes a built-in
+> gate that skips execution when the actor is not `dependabot[bot]`. Adding
+> the `if` avoids spinning up the job entirely.
 
 ## Latest versions
 

--- a/actions/triage-dependabot-prs/README.md.hbs
+++ b/actions/triage-dependabot-prs/README.md.hbs
@@ -1,0 +1,43 @@
+# {{name}}
+
+{{description}}
+
+Triages Dependabot pull requests by automatically enabling auto-merge and
+approving dependency updates. The action validates its context on entry and
+skips gracefully when the actor is not `dependabot[bot]`.
+
+## Usage
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  dependabot:
+    name: Dependabot automations
+    runs-on: ubuntu-latest
+    if: $\{{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: abinnovision/actions@triage-dependabot-prs-v1
+```
+
+> **Note:** The `if` condition is optional. The action includes a built-in
+> gate that skips execution when the actor is not `dependabot[bot]`. Adding
+> the `if` avoids spinning up the job entirely.
+
+## Latest versions
+
+{{{version-examples type="action" name=name version=version}}}
+
+## Inputs
+
+{{> inputs-table inputs}}
+
+## Outputs
+
+{{> outputs-table outputs}}

--- a/actions/triage-dependabot-prs/action.yml
+++ b/actions/triage-dependabot-prs/action.yml
@@ -1,0 +1,149 @@
+name: Triage Dependabot PRs
+author: "abi group GmbH"
+description: |
+  Automatically approve and enable auto-merge for Dependabot pull requests.
+  By default, all update types (major, minor, patch) are auto-approved and
+  auto-merged via squash.
+
+inputs:
+  token:
+    required: false
+    default: ${{ github.token }}
+    description: |
+      GitHub token with pull-requests:write and contents:write permissions.
+  approve-update-types:
+    required: false
+    default: "major minor patch"
+    description: |
+      Space-separated list of semver update types to auto-approve.
+      Supported values: major, minor, patch.
+      Auto-merge is enabled regardless of this setting.
+  auto-merge:
+    required: false
+    default: "true"
+    description: |
+      Whether to enable auto-merge on the PR.
+  merge-method:
+    required: false
+    default: "squash"
+    description: |
+      Merge method to use. One of: squash, merge, rebase.
+
+outputs:
+  update-type:
+    description: "The semver update type detected by dependabot/fetch-metadata."
+    value: ${{ steps.metadata.outputs.update-type }}
+  approved:
+    description: "Whether the PR was approved by this action."
+    value: ${{ steps.approve.outputs.approved }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      name: Validate context
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        ACTOR: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$EVENT_NAME" != "pull_request" && "$EVENT_NAME" != "pull_request_target" ]]; then
+          echo "::error::triage-dependabot-prs requires a pull_request or pull_request_target trigger (got '$EVENT_NAME')."
+          exit 1
+        fi
+
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "::error::No pull request number found in the event payload."
+          exit 1
+        fi
+
+        if [[ "$ACTOR" != "dependabot[bot]" ]]; then
+          echo "::warning::This PR was not opened by dependabot (actor: '$ACTOR'). Skipping."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "skip=false" >> "$GITHUB_OUTPUT"
+
+    - id: metadata
+      name: Fetch Dependabot metadata
+      if: steps.gate.outputs.skip != 'true'
+      uses: dependabot/fetch-metadata@v3
+      with:
+        github-token: ${{ inputs.token }}
+
+    - id: review-status
+      name: Resolve review status
+      if: steps.gate.outputs.skip != 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+
+        REVIEW_COUNT=$(gh pr view "$PR_NUMBER" --json reviews --jq '.reviews | length')
+        if [[ "$REVIEW_COUNT" == "0" ]]; then
+          echo "has_reviews=false" >> "$GITHUB_OUTPUT"
+          echo "last_review_dismissed=false" >> "$GITHUB_OUTPUT"
+        else
+          LAST_STATE=$(gh pr view "$PR_NUMBER" --json reviews --jq '.reviews[-1].state')
+          echo "has_reviews=true" >> "$GITHUB_OUTPUT"
+          if [[ "$LAST_STATE" == "DISMISSED" ]]; then
+            echo "last_review_dismissed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "last_review_dismissed=false" >> "$GITHUB_OUTPUT"
+          fi
+        fi
+
+    - id: auto-merge
+      name: Enable auto-merge
+      if: steps.gate.outputs.skip != 'true' && inputs.auto-merge == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        MERGE_METHOD: ${{ inputs.merge-method }}
+      run: |
+        set -euo pipefail
+        gh pr merge --auto --"$MERGE_METHOD" "$PR_URL"
+
+    - id: approve
+      name: Auto-approve PR
+      if: steps.gate.outputs.skip != 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        HAS_REVIEWS: ${{ steps.review-status.outputs.has_reviews }}
+        LAST_REVIEW_DISMISSED: ${{ steps.review-status.outputs.last_review_dismissed }}
+        APPROVE_TYPES: ${{ inputs.approve-update-types }}
+      run: |
+        set -euo pipefail
+
+        SHOULD_APPROVE=false
+        for type in $APPROVE_TYPES; do
+          if [[ "$UPDATE_TYPE" == "version-update:semver-${type}" ]]; then
+            SHOULD_APPROVE=true
+            break
+          fi
+        done
+
+        if [[ "$SHOULD_APPROVE" != "true" ]]; then
+          echo "Update type '$UPDATE_TYPE' not in approve list ($APPROVE_TYPES). Skipping approval."
+          echo "approved=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$HAS_REVIEWS" == "false" || "$LAST_REVIEW_DISMISSED" == "true" ]]; then
+          echo "Approving PR for update type: $UPDATE_TYPE"
+          gh pr review --approve "$PR_URL"
+          echo "approved=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "PR already has non-dismissed reviews. Skipping approval."
+          echo "approved=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/actions/triage-dependabot-prs/package.json
+++ b/actions/triage-dependabot-prs/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "triage-dependabot-prs",
+	"version": "0.0.0",
+	"license": "Apache-2.0",
+	"author": {
+		"name": "abi group GmbH",
+		"email": "info@abigroup.io",
+		"url": "https://abigroup.io/"
+	},
+	"files": [
+		"action.yml",
+		"README.md",
+		"CHANGELOG.md",
+		"LICENSE.md"
+	],
+	"scripts": {
+		"format:check": "prettier --check '*.{json,json5,yaml,yml,md}'",
+		"format:fix": "prettier --write '*.{json,json5,yaml,yml,md}'"
+	},
+	"lint-staged": {
+		"*.{json,json5,yaml,yml,md}": [
+			"prettier --write"
+		]
+	},
+	"prettier": "@abinnovision/prettier-config",
+	"devDependencies": {
+		"@abinnovision/prettier-config": "^2.2.0",
+		"prettier": "^3.9.5"
+	}
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,9 @@
 		"actions/setup-tools": {
 			"extra-files": ["README.md"]
 		},
+		"actions/triage-dependabot-prs": {
+			"extra-files": ["README.md"]
+		},
 		"workflows/release": {
 			"extra-files": ["README.md"]
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -4525,6 +4525,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"triage-dependabot-prs@workspace:actions/triage-dependabot-prs":
+  version: 0.0.0-use.local
+  resolution: "triage-dependabot-prs@workspace:actions/triage-dependabot-prs"
+  dependencies:
+    "@abinnovision/prettier-config": "npm:^2.2.0"
+    prettier: "npm:^3.9.5"
+  languageName: unknown
+  linkType: soft
+
 "trim-newlines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"


### PR DESCRIPTION
Adds a new reusable composite action `triage-dependabot-prs` that automates Dependabot PR triage — auto-approving and enabling auto-merge based on configurable semver update types and merge method. This replaces the inline shell logic previously embedded in workflows with a proper, reusable action that includes input validation, review-status checks, and error handling. The local `pr-utils.yaml` workflow is intentionally left unchanged for now and will be migrated separately.