### PR TITLE
build: replace actionDependencies with standard dependencies for internal versioning

### DIFF
--- a/actions/exchange-github-token/package.json
+++ b/actions/exchange-github-token/package.json
@@ -24,8 +24,8 @@
 		]
 	},
 	"prettier": "@abinnovision/prettier-config",
-	"actionDependencies": {
-		"setup-oidc-token-cli": "^1.0.0"
+	"dependencies": {
+		"setup-oidc-token-cli": "workspace:^"
 	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "^2.2.0",

--- a/actions/setup-tools/package.json
+++ b/actions/setup-tools/package.json
@@ -23,11 +23,11 @@
 		]
 	},
 	"prettier": "@abinnovision/prettier-config",
+	"dependencies": {
+		"setup-node": "workspace:^"
+	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "^2.2.0",
 		"prettier": "^3.9.5"
-	},
-	"actionDependencies": {
-		"setup-node": "^1.0.0"
 	}
 }

--- a/scripts/check-action-refs.ts
+++ b/scripts/check-action-refs.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 interface PackageJson {
 	name: string;
 	version: string;
-	actionDependencies?: Record<string, string>;
+	dependencies?: Record<string, string>;
 }
 
 /**
@@ -80,12 +80,13 @@ function findYamlFilesToCheck(rootDir: string): string[] {
 }
 
 /**
- * Reads actionDependencies from a package's package.json, if it belongs to
- * the actions/ or workflows/ directories.
+ * Reads dependencies from a package's package.json, if it belongs to
+ * the actions/ or workflows/ directories, filtered to internal packages.
  */
 function getActionDependencies(
 	rootDir: string,
 	filePath: string,
+	internalNames: Set<string>,
 ): Record<string, string> | null {
 	const relative = path.relative(rootDir, filePath);
 	const parts = relative.split(path.sep);
@@ -100,7 +101,14 @@ function getActionDependencies(
 	if (!fs.existsSync(pkgPath)) return null;
 
 	const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as PackageJson;
-	return pkg.actionDependencies ?? {};
+	const deps = pkg.dependencies ?? {};
+	const filtered: Record<string, string> = {};
+	for (const [name, version] of Object.entries(deps)) {
+		if (internalNames.has(name)) {
+			filtered[name] = version;
+		}
+	}
+	return filtered;
 }
 
 function main() {
@@ -120,8 +128,8 @@ function main() {
 		const content = fs.readFileSync(filePath, "utf8");
 		const relative = path.relative(rootDir, filePath);
 
-		// Get actionDependencies if this is a published package
-		const actionDeps = getActionDependencies(rootDir, filePath);
+		// Get dependencies if this is a published package
+		const actionDeps = getActionDependencies(rootDir, filePath, internalNames);
 
 		let match;
 		// Reset lastIndex since we reuse the regex
@@ -141,41 +149,12 @@ function main() {
 				);
 			}
 
-			// Check 2: If this is a published package, the dep must be declared in actionDependencies
+			// Check 2: If this is a published package, the dep must be declared in dependencies
 			if (actionDeps !== null && tag === "dev") {
 				if (!actionDeps[name]) {
 					errors.push(
-						`${relative}: References internal action '${name}' but it is not declared in actionDependencies`,
+						`${relative}: References internal action '${name}' but it is not declared in dependencies`,
 					);
-				} else {
-					// Validate the range format and version compatibility
-					const rangePattern = /^(\^|~)?(\d+)\.(\d+)\.\d+$/;
-					const rangeMatch = actionDeps[name].match(rangePattern);
-					if (!rangeMatch) {
-						errors.push(
-							`${relative}: actionDependencies['${name}'] has invalid range '${actionDeps[name]}'. Expected '^X.Y.Z', '~X.Y.Z', or 'X.Y.Z'.`,
-						);
-					} else {
-						const [, prefix, major, minor] = rangeMatch;
-						const actualVersion = internalPackages.get(name);
-						if (actualVersion) {
-							const [actualMajor, actualMinor] =
-								actualVersion.split(".");
-							if (prefix === "^" && actualMajor !== major) {
-								errors.push(
-									`${relative}: actionDependency '${name}' declares range '${actionDeps[name]}' but workspace version is ${actualVersion} (major version mismatch)`,
-								);
-							} else if (
-								prefix === "~" &&
-								(actualMajor !== major ||
-									actualMinor !== minor)
-							) {
-								errors.push(
-									`${relative}: actionDependency '${name}' declares range '${actionDeps[name]}' but workspace version is ${actualVersion} (major.minor mismatch)`,
-								);
-							}
-						}
-					}
 				}
 			}
 		}
@@ -193,7 +172,7 @@ function main() {
 			"Version pinning happens automatically during publish.",
 		);
 		console.error(
-			"Published packages must declare internal deps in 'actionDependencies' in package.json.",
+			"Published packages must declare internal deps in 'dependencies' in package.json.",
 		);
 		process.exit(1);
 	}

--- a/scripts/resolve-action-refs.ts
+++ b/scripts/resolve-action-refs.ts
@@ -6,65 +6,7 @@ import path from "node:path";
 interface PackageJson {
 	name: string;
 	version: string;
-	actionDependencies?: Record<string, string>;
-}
-
-interface ResolvedDep {
-	name: string;
-	version: string;
-	tag: string;
-}
-
-/**
- * Parses a semver range from actionDependencies and resolves it to the
- * appropriate Git tag level based on the actual workspace version.
- *
- * - `^X.Y.Z` → `vX` (major floating tag)
- * - `~X.Y.Z` → `vX.Y` (minor floating tag)
- * - `X.Y.Z`  → `vX.Y.Z` (exact tag)
- */
-function resolveTagFromRange(
-	depName: string,
-	range: string,
-	actualVersion: string,
-): string {
-	const semverPattern = /^(\^|~)?(\d+)\.(\d+)\.(\d+)$/;
-	const match = range.match(semverPattern);
-
-	if (!match) {
-		console.error(
-			`Error: Invalid actionDependencies range '${range}' for '${depName}'. Expected '^X.Y.Z', '~X.Y.Z', or 'X.Y.Z'.`,
-		);
-		process.exit(1);
-	}
-
-	const [, prefix, major, minor] = match;
-	const actualParts = actualVersion.split(".");
-	const actualMajor = actualParts[0];
-	const actualMinor = actualParts[1];
-
-	if (prefix === "^") {
-		if (actualMajor !== major) {
-			console.error(
-				`Error: actionDependency '${depName}' declares range '${range}' but workspace version is ${actualVersion} (major version mismatch).`,
-			);
-			process.exit(1);
-		}
-		return `v${major}`;
-	}
-
-	if (prefix === "~") {
-		if (actualMajor !== major || actualMinor !== minor) {
-			console.error(
-				`Error: actionDependency '${depName}' declares range '${range}' but workspace version is ${actualVersion} (major.minor mismatch).`,
-			);
-			process.exit(1);
-		}
-		return `v${major}.${minor}`;
-	}
-
-	// Exact version
-	return `v${actualVersion}`;
+	dependencies?: Record<string, string>;
 }
 
 function parseArgs(): { stagingDir: string; workspaceRoot: string } {
@@ -106,7 +48,7 @@ function findPackageInWorkspace(
 	}
 
 	console.error(
-		`Error: actionDependency '${depName}' not found in workspace. Checked actions/${depName}/ and workflows/${depName}/`,
+		`Error: dependency '${depName}' not found in workspace. Checked actions/${depName}/ and workflows/${depName}/`,
 	);
 	process.exit(1);
 }
@@ -169,31 +111,32 @@ function main() {
 	const pkgJson = JSON.parse(
 		fs.readFileSync(pkgJsonPath, "utf8"),
 	) as PackageJson;
-	const actionDeps = pkgJson.actionDependencies ?? {};
 
-	if (Object.keys(actionDeps).length === 0) {
+	const internalNames = discoverInternalPackages(workspaceRoot);
+	const allDeps = pkgJson.dependencies ?? {};
+	const actionDepNames = Object.keys(allDeps).filter(name =>
+		internalNames.has(name),
+	);
+
+	if (actionDepNames.length === 0) {
 		console.log(
-			`[${pkgJson.name}] No actionDependencies declared, skipping resolution.`,
+			`[${pkgJson.name}] No dependencies declared, skipping resolution.`,
 		);
 		return;
 	}
 
 	// Resolve each dependency's version and tag from workspace
-	const resolvedDeps: ResolvedDep[] = Object.entries(actionDeps).map(
-		([name, range]) => {
-			const depPkg = findPackageInWorkspace(workspaceRoot, name);
-			const tag = resolveTagFromRange(name, range, depPkg.version);
-			return { name, version: depPkg.version, tag };
-		},
-	);
+	const resolvedDeps = actionDepNames.map(name => {
+		const depPkg = findPackageInWorkspace(workspaceRoot, name);
+		return { name, version: depPkg.version, tag: `v${depPkg.version}` };
+	});
 
 	console.log(
 		`[${pkgJson.name}] Resolving ${resolvedDeps.length} action dependency reference(s)...`,
 	);
 
 	// Discover all internal package names for undeclared-ref detection
-	const internalNames = discoverInternalPackages(workspaceRoot);
-	const declaredNames = new Set(Object.keys(actionDeps));
+	const declaredNames = new Set(actionDepNames);
 
 	// Find all YAML files in staging dir
 	const yamlFiles = findYamlFiles(stagingDir);
@@ -233,7 +176,7 @@ function main() {
 			const refName = match[1];
 			if (internalNames.has(refName) && !declaredNames.has(refName)) {
 				undeclaredRefs.push(
-					`${path.relative(stagingDir, filePath)}: references internal action '${refName}' not declared in actionDependencies`,
+					`${path.relative(stagingDir, filePath)}: references internal action '${refName}' not declared in dependencies`,
 				);
 			}
 		}
@@ -246,7 +189,7 @@ function main() {
 	// Error on undeclared refs
 	if (undeclaredRefs.length > 0) {
 		console.error(
-			"Error: Found references to internal actions not declared in actionDependencies:",
+			"Error: Found references to internal actions not declared in dependencies:",
 		);
 		for (const ref of undeclaredRefs) {
 			console.error(`  - ${ref}`);
@@ -258,7 +201,7 @@ function main() {
 	for (const dep of resolvedDeps) {
 		if (!usedDeps.has(dep.name)) {
 			console.warn(
-				`Warning: actionDependency '${dep.name}' is declared but no matching -dev reference found in YAML files`,
+				`Warning: dependency '${dep.name}' is declared but no matching -dev reference found in YAML files`,
 			);
 		}
 	}

--- a/workflows/gitops-deploy/package.json
+++ b/workflows/gitops-deploy/package.json
@@ -23,12 +23,12 @@
 		]
 	},
 	"prettier": "@abinnovision/prettier-config",
+	"dependencies": {
+		"setup-k8s-tools": "workspace:^",
+		"setup-node": "workspace:^"
+	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "^2.2.0",
 		"prettier": "^3.9.5"
-	},
-	"actionDependencies": {
-		"setup-k8s-tools": "^2.0.0",
-		"setup-node": "^1.0.0"
 	}
 }

--- a/workflows/gitops-update-tags/package.json
+++ b/workflows/gitops-update-tags/package.json
@@ -23,14 +23,14 @@
 		]
 	},
 	"prettier": "@abinnovision/prettier-config",
+	"dependencies": {
+		"exchange-github-token": "workspace:^",
+		"setup-gcp": "workspace:^",
+		"setup-k8s-tools": "workspace:^",
+		"setup-node": "workspace:^"
+	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "^2.2.0",
 		"prettier": "^3.9.5"
-	},
-	"actionDependencies": {
-		"exchange-github-token": "^1.0.0",
-		"setup-gcp": "^1.0.0",
-		"setup-k8s-tools": "^2.0.0",
-		"setup-node": "^1.0.0"
 	}
 }

--- a/workflows/polyglot-monorepo-stack/package.json
+++ b/workflows/polyglot-monorepo-stack/package.json
@@ -23,14 +23,14 @@
 		]
 	},
 	"prettier": "@abinnovision/prettier-config",
+	"dependencies": {
+		"exchange-github-token": "workspace:^",
+		"release": "workspace:^",
+		"setup-gcp": "workspace:^",
+		"setup-tools": "workspace:^"
+	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "^2.2.0",
 		"prettier": "^3.9.5"
-	},
-	"actionDependencies": {
-		"exchange-github-token": "^1.0.0",
-		"release": "^2.0.0",
-		"setup-gcp": "^1.0.0",
-		"setup-tools": "^1.0.0"
 	}
 }

--- a/workflows/release/package.json
+++ b/workflows/release/package.json
@@ -23,13 +23,13 @@
 		]
 	},
 	"prettier": "@abinnovision/prettier-config",
+	"dependencies": {
+		"exchange-github-token": "workspace:^",
+		"run-release-please": "workspace:^",
+		"setup-gcp": "workspace:^"
+	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "^2.2.0",
 		"prettier": "^3.9.5"
-	},
-	"actionDependencies": {
-		"exchange-github-token": "^1.0.0",
-		"run-release-please": "^1.0.0",
-		"setup-gcp": "^1.0.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,12 +2762,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exchange-github-token@workspace:actions/exchange-github-token":
+"exchange-github-token@workspace:^, exchange-github-token@workspace:actions/exchange-github-token":
   version: 0.0.0-use.local
   resolution: "exchange-github-token@workspace:actions/exchange-github-token"
   dependencies:
     "@abinnovision/prettier-config": "npm:^2.2.0"
     prettier: "npm:^3.9.5"
+    setup-oidc-token-cli: "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -2975,6 +2976,8 @@ __metadata:
   dependencies:
     "@abinnovision/prettier-config": "npm:^2.2.0"
     prettier: "npm:^3.9.5"
+    setup-k8s-tools: "workspace:^"
+    setup-node: "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -2983,7 +2986,11 @@ __metadata:
   resolution: "gitops-update-tags@workspace:workflows/gitops-update-tags"
   dependencies:
     "@abinnovision/prettier-config": "npm:^2.2.0"
+    exchange-github-token: "workspace:^"
     prettier: "npm:^3.9.5"
+    setup-gcp: "workspace:^"
+    setup-k8s-tools: "workspace:^"
+    setup-node: "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -3882,7 +3889,11 @@ __metadata:
   resolution: "polyglot-monorepo-stack@workspace:workflows/polyglot-monorepo-stack"
   dependencies:
     "@abinnovision/prettier-config": "npm:^2.2.0"
+    exchange-github-token: "workspace:^"
     prettier: "npm:^3.9.5"
+    release: "workspace:^"
+    setup-gcp: "workspace:^"
+    setup-tools: "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -4038,12 +4049,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"release@workspace:workflows/release":
+"release@workspace:^, release@workspace:workflows/release":
   version: 0.0.0-use.local
   resolution: "release@workspace:workflows/release"
   dependencies:
     "@abinnovision/prettier-config": "npm:^2.2.0"
+    exchange-github-token: "workspace:^"
     prettier: "npm:^3.9.5"
+    run-release-please: "workspace:^"
+    setup-gcp: "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -4156,7 +4170,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"run-release-please@workspace:actions/run-release-please":
+"run-release-please@workspace:^, run-release-please@workspace:actions/run-release-please":
   version: 0.0.0-use.local
   resolution: "run-release-please@workspace:actions/run-release-please"
   dependencies:
@@ -4192,7 +4206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setup-gcp@workspace:actions/setup-gcp":
+"setup-gcp@workspace:^, setup-gcp@workspace:actions/setup-gcp":
   version: 0.0.0-use.local
   resolution: "setup-gcp@workspace:actions/setup-gcp"
   dependencies:
@@ -4201,7 +4215,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"setup-k8s-tools@workspace:actions/setup-k8s-tools":
+"setup-k8s-tools@workspace:^, setup-k8s-tools@workspace:actions/setup-k8s-tools":
   version: 0.0.0-use.local
   resolution: "setup-k8s-tools@workspace:actions/setup-k8s-tools"
   dependencies:
@@ -4217,7 +4231,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"setup-node@workspace:actions/setup-node":
+"setup-node@workspace:^, setup-node@workspace:actions/setup-node":
   version: 0.0.0-use.local
   resolution: "setup-node@workspace:actions/setup-node"
   dependencies:
@@ -4226,7 +4240,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"setup-oidc-token-cli@workspace:actions/setup-oidc-token-cli":
+"setup-oidc-token-cli@workspace:^, setup-oidc-token-cli@workspace:actions/setup-oidc-token-cli":
   version: 0.0.0-use.local
   resolution: "setup-oidc-token-cli@workspace:actions/setup-oidc-token-cli"
   dependencies:
@@ -4242,12 +4256,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"setup-tools@workspace:actions/setup-tools":
+"setup-tools@workspace:^, setup-tools@workspace:actions/setup-tools":
   version: 0.0.0-use.local
   resolution: "setup-tools@workspace:actions/setup-tools"
   dependencies:
     "@abinnovision/prettier-config": "npm:^2.2.0"
     prettier: "npm:^3.9.5"
+    setup-node: "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Replaces the custom `actionDependencies` package.json field with standard `dependencies` using Yarn's `workspace:^` protocol across 6 packages
- Simplifies `resolve-action-refs.ts` by removing range-parsing logic (`^`/`~`/exact) -- always resolves to exact version tags now
- Simplifies `check-action-refs.ts` by removing range format and version compatibility validation
- The release-please `node-workspace` plugin now handles internal version propagation automatically, removing the need for manual `actionDependencies` maintenance

## Test plan

- [x] `yarn install` resolves cleanly
- [x] `yarn build` passes
- [x] `yarn tsx scripts/check-action-refs.ts` validates all 14 YAML files
- [x] No `actionDependencies` references remain in the codebase
- [ ] Verify first release-please PR after merge correctly propagates version bumps through the dependency chain