### PR TITLE
feat(gitops-deploy): use oidc-token-cli for DEX token exchange

### DIFF
--- a/workflows/gitops-deploy/package.json
+++ b/workflows/gitops-deploy/package.json
@@ -25,7 +25,8 @@
 	"prettier": "@abinnovision/prettier-config",
 	"dependencies": {
 		"setup-k8s-tools": "workspace:^",
-		"setup-node": "workspace:^"
+		"setup-node": "workspace:^",
+		"setup-oidc-token-cli": "workspace:^"
 	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "^2.2.0",

--- a/workflows/gitops-deploy/workflow.yaml
+++ b/workflows/gitops-deploy/workflow.yaml
@@ -463,49 +463,51 @@ jobs:
           echo "application_name=$argocd_app" >> $GITHUB_OUTPUT
           echo "ArgoCD application: $argocd_app"
 
+      - &setup-oidc-token-cli
+        name: Setup oidc-token-cli
+        if: inputs.auth-method == 'dex'
+        uses: abinnovision/actions@setup-oidc-token-cli-dev
+
       - &auth-dex
         name: Authenticate with ArgoCD (DEX)
         if: inputs.auth-method == 'dex'
         id: auth-dex
+        env:
+          DEX_ENDPOINT: ${{ secrets.DEX_ENDPOINT }}
+          DEX_CLIENT: ${{ secrets.DEX_GITHUB_ACTIONS_CLIENT }}
+          DEX_CONNECTOR: ${{ secrets.DEX_GITHUB_ACTIONS_CONNECTOR }}
+          ARGOCD_SERVER: ${{ inputs.argocd-server }}
         run: |
           set -euo pipefail
 
-          # Get GitHub OIDC token
-          ID_TOKEN=$(curl -s \
-            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=core-argocd-github-actions" \
-            | jq -r ".value")
+          # DEX_GITHUB_ACTIONS_CLIENT is a combined "client_id:client_secret"
+          CLIENT_ID="${DEX_CLIENT%%:*}"
+          CLIENT_SECRET="${DEX_CLIENT#*:}"
 
-          echo "::add-mask::$ID_TOKEN"
+          # Exchange the GitHub Actions OIDC token for a DEX token (RFC 8693).
+          # oidc-token fetches the GitHub OIDC token itself via
+          # --subject-token-source github-actions (requires id-token: write).
+          DEX_TOKEN=$(OIDC_TOKEN_CLIENT_SECRET="$CLIENT_SECRET" oidc-token \
+            --issuer "$DEX_ENDPOINT" \
+            --client-id "$CLIENT_ID" \
+            --client-auth-method client_secret_basic \
+            --grant-type token-exchange \
+            --subject-token-source github-actions \
+            --subject-token-type urn:ietf:params:oauth:token-type:id_token \
+            --requested-token-type urn:ietf:params:oauth:token-type:id_token \
+            --audience core-argocd-github-actions \
+            --scope "openid profile groups" \
+            --extra "connector_id=$DEX_CONNECTOR")
 
-          if [[ -z "$ID_TOKEN" || "$ID_TOKEN" == "null" ]]; then
-            echo "::error::Failed to get GitHub OIDC token"
-            exit 1
-          fi
-
-          # Exchange with DEX
-          DEX_TOKEN_RESPONSE=$(curl -s \
-            ${{ secrets.DEX_ENDPOINT }}/token \
-            --user "${{ secrets.DEX_GITHUB_ACTIONS_CLIENT }}" \
-            --data-urlencode "connector_id=${{ secrets.DEX_GITHUB_ACTIONS_CONNECTOR }}" \
-            --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
-            --data-urlencode "scope=openid profile groups" \
-            --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:id_token" \
-            --data-urlencode "subject_token=$ID_TOKEN" \
-            --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:id_token")
-
-          DEX_TOKEN=$(jq -r .access_token <<< "$DEX_TOKEN_RESPONSE")
-
-          if [[ -z "$DEX_TOKEN" || "$DEX_TOKEN" == "null" ]]; then
+          if [[ -z "$DEX_TOKEN" ]]; then
             echo "::error::Failed to exchange token with DEX"
-            echo "Response: $DEX_TOKEN_RESPONSE"
             exit 1
           fi
 
           echo "::add-mask::$DEX_TOKEN"
 
           # Build CLI arguments
-          ARGOCD_CLI_ARGS="--grpc-web --server ${{ inputs.argocd-server }} --auth-token ${DEX_TOKEN}"
+          ARGOCD_CLI_ARGS="--grpc-web --server $ARGOCD_SERVER --auth-token $DEX_TOKEN"
           echo "::add-mask::$ARGOCD_CLI_ARGS"
 
           echo "argocd_cli_args=$ARGOCD_CLI_ARGS" >> $GITHUB_OUTPUT
@@ -644,6 +646,7 @@ jobs:
           echo "application_name=$argocd_app" >> $GITHUB_OUTPUT
           echo "ArgoCD application: $argocd_app"
 
+      - *setup-oidc-token-cli
       - *auth-dex
       - *auth-token
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,6 +2978,7 @@ __metadata:
     prettier: "npm:^3.9.5"
     setup-k8s-tools: "workspace:^"
     setup-node: "workspace:^"
+    setup-oidc-token-cli: "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Replaces the hand-rolled `curl`/`jq` DEX OIDC token exchange in the `gitops-deploy` workflow's ArgoCD authentication with the `abinnovision/oidc-token-cli` (`oidc-token`) binary, installed via the internal `setup-oidc-token-cli` action and matching the existing `exchange-github-token` pattern. Both curls (GitHub OIDC fetch + RFC 8693 exchange) are gone: `oidc-token` now fetches the GitHub OIDC token itself via `--subject-token-source github-actions`, uses `client_secret_basic` auth (secret passed via env, not argv), and carries DEX's `connector_id` through `--extra`. Adds `setup-oidc-token-cli` as a `workspace:^` dependency and updates `yarn.lock`. Note: the CLI's single `--audience` flag drives both the GitHub-token audience and the exchange `audience` form field, so the exchange body now also carries `audience=core-argocd-github-actions` (previously absent) — harmless as long as DEX ignores audience in token-exchange. The `token` auth-method path is unchanged.