### PR TITLE
feat(exchange-github-token): add resources input aligned with broker prefixes

### DIFF
--- a/actions/exchange-github-token/README.md
+++ b/actions/exchange-github-token/README.md
@@ -25,9 +25,11 @@ steps:
       scope: |
         contents:write
         pull_requests:write
-      repositories: |
-        my-org/repo-a
-        my-org/repo-b
+      resources: |
+        repo:my-org/repo-a
+        repo:my-org/repo-b
+        # or an org-wide token: org:my-org
+        # or an enterprise-wide token: enterprise:my-enterprise
 
   - name: Use the token
     env:
@@ -45,14 +47,15 @@ This action can be used with different version ranges. The following ranges are 
 
 ## Inputs
 
-| Input                    | Description                                                                           | Required | Default               |
-| :----------------------- | :------------------------------------------------------------------------------------ | :------- | :-------------------- |
-| `broker-url`             | Base URL of the token broker service (used as OIDC issuer for discovery)              | Yes      |                       |
-| `audience`               | OIDC audience for the token broker (defaults to broker-url)                           | No       | _empty_               |
-| `scope`                  | Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)     | Yes      |                       |
-| `repositories`           | Repositories the token should access, whitespace-separated (defaults to current repo) | No       | _empty_               |
-| `github-token`           | Token for downloading oidc-token-cli from GitHub releases                             | No       | `${{ github.token }}` |
-| `oidc-token-cli-version` | Version of oidc-token-cli to install                                                  | No       | `latest`              |
+| Input                    | Description                                                                                                                                                                                                                                                  | Required | Default               |
+| :----------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :-------------------- |
+| `broker-url`             | Base URL of the token broker service (used as OIDC issuer for discovery)                                                                                                                                                                                     | Yes      |                       |
+| `audience`               | OIDC audience for the token broker (defaults to broker-url)                                                                                                                                                                                                  | No       | _empty_               |
+| `scope`                  | Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)                                                                                                                                                                            | Yes      |                       |
+| `resources`              | Resources the token should access, whitespace-separated, using typed prefixes: repo:owner/name, org:name, or enterprise:slug. Passed through to the broker as --resource. Defaults to the current repository when neither resources nor repositories is set. | No       | _empty_               |
+| `repositories`           | Deprecated: use `resources`. Repositories the token should access, whitespace-separated.                                                                                                                                                                     | No       | _empty_               |
+| `github-token`           | Token for downloading oidc-token-cli from GitHub releases                                                                                                                                                                                                    | No       | `${{ github.token }}` |
+| `oidc-token-cli-version` | Version of oidc-token-cli to install                                                                                                                                                                                                                         | No       | `latest`              |
 
 ## Outputs
 

--- a/actions/exchange-github-token/README.md.hbs
+++ b/actions/exchange-github-token/README.md.hbs
@@ -25,9 +25,11 @@ steps:
       scope: |
         contents:write
         pull_requests:write
-      repositories: |
-        my-org/repo-a
-        my-org/repo-b
+      resources: |
+        repo:my-org/repo-a
+        repo:my-org/repo-b
+        # or an org-wide token: org:my-org
+        # or an enterprise-wide token: enterprise:my-enterprise
 
   - name: Use the token
     env:

--- a/actions/exchange-github-token/action.yml
+++ b/actions/exchange-github-token/action.yml
@@ -11,9 +11,16 @@ inputs:
   scope:
     description: "Permission scopes, whitespace-separated (e.g. contents:write pull_requests:write)"
     required: true
-  repositories:
-    description: "Repositories the token should access, whitespace-separated (defaults to current repo)"
+  resources:
+    description: >-
+      Resources the token should access, whitespace-separated, using typed prefixes:
+      repo:owner/name, org:name, or enterprise:slug. Passed through to the broker as
+      --resource. Defaults to the current repository when neither resources nor repositories is set.
     required: false
+  repositories:
+    description: "Deprecated: use `resources`. Repositories the token should access, whitespace-separated."
+    required: false
+    deprecationMessage: "The 'repositories' input is deprecated; use 'resources' with typed prefixes (repo:/org:/enterprise:) instead."
   github-token:
     description: "Token for downloading oidc-token-cli from GitHub releases"
     required: false
@@ -48,6 +55,7 @@ runs:
         BROKER_URL: ${{ inputs.broker-url }}
         AUDIENCE: ${{ inputs.audience }}
         SCOPE: ${{ inputs.scope }}
+        RESOURCES: ${{ inputs.resources }}
         REPOSITORIES: ${{ inputs.repositories }}
       run: |
         set -euo pipefail
@@ -65,12 +73,24 @@ runs:
         SCOPE_VALUE=$(echo "$SCOPE" | tr '\n' ' ' | xargs)
         ARGS+=(--scope "$SCOPE_VALUE")
 
-        # Add repositories as repeated --resource flags
+        # Emit a deprecation warning if the legacy repositories input is used
         if [ -n "$REPOSITORIES" ]; then
-          for repo in $(echo "$REPOSITORIES" | tr '\n' ' ' | xargs -n1); do
-            ARGS+=(--resource "$repo")
-          done
-        else
+          echo "::warning::The 'repositories' input is deprecated; use 'resources' with typed prefixes (repo:/org:/enterprise:) instead."
+        fi
+
+        # Collect resources: resources (prefixed) first, then legacy repositories
+        RESOURCE_COUNT=0
+        for res in $(echo "$RESOURCES" | tr '\n' ' ' | xargs -n1); do
+          ARGS+=(--resource "$res")
+          RESOURCE_COUNT=$((RESOURCE_COUNT + 1))
+        done
+        for repo in $(echo "$REPOSITORIES" | tr '\n' ' ' | xargs -n1); do
+          ARGS+=(--resource "$repo")
+          RESOURCE_COUNT=$((RESOURCE_COUNT + 1))
+        done
+
+        # Default to the current repository only when neither input was provided
+        if [ "$RESOURCE_COUNT" -eq 0 ]; then
           ARGS+=(--resource "$GITHUB_REPOSITORY")
         fi
 


### PR DESCRIPTION
Adds a canonical `resources` input to the `exchange-github-token` action that accepts the token broker's typed resource prefixes (`repo:owner/name`, `org:name`, `enterprise:slug`), passed through to `oidc-token-cli` as `--resource`, so callers can request org- or enterprise-wide tokens. The legacy `repositories` input is deprecated but kept as a working alias, emitting a warning when used. The current-repository fallback now applies only when neither input is set. Regenerated `README.md` from the updated `action.yml` and `README.md.hbs`.