### PR TITLE
feat(gitops-update-tags): report run details via job summary

### DIFF
--- a/workflows/gitops-update-tags/README.md
+++ b/workflows/gitops-update-tags/README.md
@@ -10,6 +10,7 @@ Updates image tags in kustomization files and creates pull requests.
 - Groups multiple updates into single PR per application
 - Formats files with prettier before committing
 - Optional automerge when all specified images are updated
+- Writes a job summary with the applied `image -> tag` updates, the pull request link, and automerge status
 
 ## Usage
 

--- a/workflows/gitops-update-tags/README.md.hbs
+++ b/workflows/gitops-update-tags/README.md.hbs
@@ -10,6 +10,7 @@ Updates image tags in kustomization files and creates pull requests.
 - Groups multiple updates into single PR per application
 - Formats files with prettier before committing
 - Optional automerge when all specified images are updated
+- Writes a job summary with the applied `image -> tag` updates, the pull request link, and automerge status
 
 ## Usage
 

--- a/workflows/gitops-update-tags/workflow.yaml
+++ b/workflows/gitops-update-tags/workflow.yaml
@@ -255,21 +255,27 @@ jobs:
           # Check if all required images are present
           IFS=',' read -ra REQUIRED <<< "${{ inputs.automerge-images }}"
           ALL_PRESENT=true
+          MISSING=""
           for img in "${REQUIRED[@]}"; do
             # Trim whitespace
             img=$(echo "$img" | xargs)
             if ! echo "$UPDATED_IMAGES" | grep -qx "$img"; then
               echo "Missing required image: $img"
               ALL_PRESENT=false
+              MISSING="${MISSING}${img}, "
             else
               echo "Found required image: $img"
             fi
           done
 
+          # Trim trailing ", " for reporting
+          MISSING="${MISSING%, }"
+
           echo "All required images present: $ALL_PRESENT"
           echo "::endgroup::"
 
           echo "AUTOMERGE_ENABLED=$ALL_PRESENT" >> "$GITHUB_ENV"
+          echo "AUTOMERGE_MISSING=$MISSING" >> "$GITHUB_ENV"
 
       - name: Create Pull Request
         id: create-pull-request
@@ -305,12 +311,30 @@ jobs:
           pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
           merge-method: squash
 
-      - name: Display PR information
+      - name: Write job summary
         if: steps.create-pull-request.outputs.pull-request-number != ''
         run: |
-          echo "::notice::Pull Request Created/Updated"
-          echo "PR Number: ${{ steps.create-pull-request.outputs.pull-request-number }}"
-          echo "PR URL: ${{ steps.create-pull-request.outputs.pull-request-url }}"
-          if [[ "$AUTOMERGE_ENABLED" == "true" ]]; then
-            echo "::notice::Automerge enabled (all required images updated)"
-          fi
+          {
+            echo "## 🔄 Image Tag Update — \`${{ inputs.application }}\`"
+            echo ""
+            echo "**This run:** \`${{ inputs.image }}\` -> \`${{ inputs.tag }}\`"
+            echo ""
+            echo "All tag updates included in the pull request:"
+            echo ""
+            echo "| Image | New Tag |"
+            echo "| :---- | :------ |"
+            while IFS='=' read -r image tag; do
+              [[ -z "$image" ]] && continue
+              echo "| \`${image}\` | \`${tag}\` |"
+            done <<< "$UPDATES"
+            echo ""
+            echo "**Pull Request:** [#${{ steps.create-pull-request.outputs.pull-request-number }}](${{ steps.create-pull-request.outputs.pull-request-url }})"
+            echo ""
+            if [[ "$AUTOMERGE_ENABLED" == "true" ]]; then
+              echo "**Automerge:** ✅ enabled — all required images updated"
+            elif [[ -n "${{ inputs.automerge-images }}" ]]; then
+              echo "**Automerge:** ⏳ pending — waiting for: ${AUTOMERGE_MISSING:-unknown}"
+            else
+              echo "**Automerge:** not configured"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/workflows/gitops-update-tags/workflow.yaml
+++ b/workflows/gitops-update-tags/workflow.yaml
@@ -338,3 +338,6 @@ jobs:
               echo "**Automerge:** not configured"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+          # Headline annotation, surfaced in the run list and the PR checks tab
+          echo "::notice title=Tag Update::${{ inputs.application }}: ${{ inputs.image }} -> ${{ inputs.tag }} (PR #${{ steps.create-pull-request.outputs.pull-request-number }})"


### PR DESCRIPTION
Replaces the two GitHub notice annotations in the `gitops-update-tags` workflow with a scannable job summary. The summary shows the image/tag this run targeted, a table of all grouped tag updates included in the PR, the pull request link, and the automerge status (listing the missing required images when automerge is still pending). READMEs are updated to document the new job-summary behavior.