### PR TITLE
ci: publish action refs in a single batched push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,14 +135,35 @@ jobs:
           git config --global user.name "${{ steps.gh-app-details.outputs.committer-name }}"
           git config --global user.email "${{ steps.gh-app-details.outputs.committer-email }}"
 
-          # Unified function to publish both actions and workflows
-          publish_item() {
+          WORKSPACE="${{ github.workspace }}"
+          PACK_DIR="/opt/temporary/packs"
+          SCRATCH="/opt/temporary/publish"
+
+          # Shared object database for the whole run. Every item becomes an orphan
+          # commit in here and all refs go out in a single push at the end.
+          git init -q -b main "$SCRATCH"
+          git --git-dir="$SCRATCH/.git" remote add origin https://x-access-token:${{ steps.gh-app-token.outputs.token }}@github.com/$GITHUB_REPOSITORY
+
+          # Runs git against the shared object database.
+          pgit() {
+            git --git-dir="$SCRATCH/.git" "$@"
+          }
+
+          # Refspecs collected by stage_item, pushed together at the end.
+          push_refs=()
+
+          # Pack every publishable workspace once, up front.
+          mkdir -p "$PACK_DIR"
+          yarn workspaces foreach -A -p \
+            --include 'actions/*' --include 'workflows/*' \
+            pack --out "$PACK_DIR/%s.tgz"
+
+          # Unified function to stage both actions and workflows
+          stage_item() {
             local path=$1
             local mode=$2  # "dev" or "release"
 
-            cd ${{ github.workspace }}
-
-            echo "Publishing '$path' ($mode mode)..."
+            echo "Staging '$path' ($mode mode)..."
 
             # Detect type and set type-specific variables
             local item_type
@@ -155,12 +176,10 @@ jobs:
               item_type="action"
               item_name=$(jq -r '.name' "$path/package.json")
               commit_prefix=""
-              staging_dir="/opt/temporary/action-$item_name"
             else
               item_type="workflow"
               item_name=$(jq -r '.name' "$path/package.json")
               commit_prefix="workflow "
-              staging_dir="/opt/temporary/workflow-$item_name"
             fi
 
             # Validate item name
@@ -168,6 +187,8 @@ jobs:
               echo "Error: Invalid or missing 'name' in $path/package.json"
               exit 1
             fi
+
+            staging_dir="/opt/temporary/$item_type-$item_name-$mode"
 
             local item_version=$(jq -r '.version' "$path/package.json")
 
@@ -177,30 +198,21 @@ jobs:
               exit 1
             fi
 
-            # Pack the package
-            yarn --cwd "$path" pack
-
-            # Create staging environment
+            # Unpack the pre-packed archive into a staging environment
+            rm -rf "$staging_dir"
             mkdir -p "$staging_dir"
-            mv "$path/package.tgz" "$staging_dir/package.tgz"
-
-            cd "$staging_dir"
-
-            # Unpack and clean up
-            tar --strip-components=1 -xzf package.tgz && rm package.tgz
+            tar -C "$staging_dir" --strip-components=1 -xzf "$PACK_DIR/$item_name.tgz"
 
             # Workflow-specific: restructure files and move the workflow file
             if [[ "$item_type" == "workflow" ]]; then
-              mkdir -p .github/workflows
-              mv workflow.yaml .github/workflows/workflow.yaml
+              mkdir -p "$staging_dir/.github/workflows"
+              mv "$staging_dir/workflow.yaml" "$staging_dir/.github/workflows/workflow.yaml"
             fi
 
             # Resolve internal action references (replace -dev with exact versions)
             if [[ "$mode" == "release" ]]; then
               echo "Resolving internal action references..."
-              cd ${{ github.workspace }}
-              yarn tsx scripts/resolve-action-refs.ts --staging-dir "$staging_dir" --workspace-root "${{ github.workspace }}"
-              cd "$staging_dir"
+              yarn tsx scripts/resolve-action-refs.ts --staging-dir "$staging_dir" --workspace-root "$WORKSPACE"
             fi
 
             # Determine branch name and version based on mode
@@ -215,67 +227,62 @@ jobs:
               version_tag="$item_version"
             fi
 
-            # Create git repository
-            git init -b "$branch_name"
-            git remote add origin https://x-access-token:${{ steps.gh-app-token.outputs.token }}@github.com/$GITHUB_REPOSITORY
-
-            # Commit all files
-            git add .
-            git commit -m "chore: release ${commit_prefix}${item_name}@${version_tag}"
-
-            # Fetch existing tags
-            git fetch origin --tags -f
-
-            dist_sha=$(git rev-list -n 1 HEAD)
-
-            # Create and collect tags based on mode
+            # Collect tags based on mode
             # Tag format is consistent for both actions and workflows: name-v{version}
             local tags_to_push=()
 
             if [[ "$mode" == "dev" ]]; then
               # Dev tags: name-dev
-              git tag -f "${item_name}-dev" "$dist_sha"
               tags_to_push+=("${item_name}-dev")
             else
               # Release tags: name-v{version} (patch, minor, major)
-              git tag -f "${item_name}-v${item_version}" "$dist_sha"
-              git tag -f "${item_name}-v$(echo $item_version | cut -d. -f1-2)" "$dist_sha"
-              git tag -f "${item_name}-v$(echo $item_version | cut -d. -f1)" "$dist_sha"
-
               tags_to_push+=("${item_name}-v${item_version}")
               tags_to_push+=("${item_name}-v$(echo $item_version | cut -d. -f1-2)")
               tags_to_push+=("${item_name}-v$(echo $item_version | cut -d. -f1)")
             fi
 
-            # Push branch
-            git push --force origin "$branch_name"
+            # Write the staged content as an orphan commit into the shared object
+            # database, using a dedicated index so items never collide.
+            local index="$SCRATCH/.git/index-$mode-$item_name"
+            local tree
+            local commit
 
-            # Push only the specific tags we created
+            rm -f "$index"
+            GIT_INDEX_FILE="$index" pgit --work-tree="$staging_dir" add -A
+            tree=$(GIT_INDEX_FILE="$index" pgit write-tree)
+            commit=$(pgit commit-tree "$tree" -m "chore: release ${commit_prefix}${item_name}@${version_tag}")
+            rm -f "$index"
+
+            pgit update-ref "refs/heads/$branch_name" "$commit"
+            push_refs+=("+refs/heads/$branch_name:refs/heads/$branch_name")
+
             for tag in "${tags_to_push[@]}"; do
-              git push --force origin "refs/tags/$tag"
+              pgit update-ref "refs/tags/$tag" "$commit"
+              push_refs+=("+refs/tags/$tag:refs/tags/$tag")
             done
 
-            # Cleanup: return to workspace and remove staging directory
-            cd ${{ github.workspace }}
+            # Cleanup: the objects live in the shared database now
             rm -rf "$staging_dir"
           }
 
-          # Phase 1: Publish releases (if any were created)
+          # Phase 1: Stage releases (if any were created)
           if [[ "${{ needs.release.outputs.releases-created }}" == "true" ]]; then
-            echo "==> Publishing versioned releases..."
-            echo '${{ needs.release.outputs.paths-released }}' | jq -cr '.[]' | while read path; do
+            echo "==> Staging versioned releases..."
+            while read -r path; do
+              [[ -n "$path" ]] || continue
+
               if [[ "$path" == "packages/"* ]]; then
                 echo "Skipping non-publishable path: $path"
                 continue
               fi
-              publish_item "$path" "release"
-            done
+              stage_item "$path" "release"
+            done <<< "$(echo '${{ needs.release.outputs.paths-released }}' | jq -cr '.[]')"
           else
             echo "==> No releases created, skipping versioned publishing"
           fi
 
-          # Phase 2: Always publish dev builds
-          echo "==> Publishing dev builds..."
+          # Phase 2: Always stage dev builds
+          echo "==> Staging dev builds..."
 
           # Get the list of all workspaces
           workspace_output=$(yarn workspaces list --json)
@@ -290,7 +297,11 @@ jobs:
             fi
           done <<< "$workspace_output"
 
-          # Publish all items as dev builds
+          # Stage all items as dev builds
           for path in "${all_locations[@]}"; do
-            publish_item "$path" "dev"
+            stage_item "$path" "dev"
           done
+
+          # Publish everything in a single push
+          echo "==> Publishing ${#push_refs[@]} refs..."
+          pgit push --atomic --force origin "${push_refs[@]}"


### PR DESCRIPTION
The publish step took ~60s for 13 items and kept getting slower as actions were added, because each item ran `git fetch origin --tags -f` — pulling all 344 tags and 151 branches into a throwaway repo without ever using the result — and then pushed its branch and tags separately, for 34 pushes per run. Items are now staged as orphan commits into one shared object database via git plumbing (`commit-tree` / `update-ref` with a per-item index), and every branch and tag ships in a single atomic push; packing also runs once up front instead of 13 times. This also converts the release loop from a pipe to a here-string, since as a subshell it would have discarded the collected refspecs.

Verified by running the previous and new scripts against a local bare remote and diffing every resulting ref with its tree hash: identical output in both the dev-only run (26 refs) and a release+dev run (34 refs), with version tags, `resolve-action-refs.ts` rewrites and the `packages/` skip all unchanged. Local wall clock dropped from 10.0s to 2.3s, which excludes the network savings that dominate in CI.