### PR TITLE
feat(polyglot-monorepo-stack): enable BuildKit SBOM generation for app images

### DIFF
--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -905,6 +905,7 @@ jobs:
         with:
           context: "."
           push: true
+          sbom: true
           file: apps/${{ matrix.entry.app }}/Dockerfile
           cache-from: ${{ steps.image-names.outputs.CACHE_FROM }}
           cache-to: ${{ steps.image-names.outputs.CACHE_TO }}


### PR DESCRIPTION
## Summary
- Enables `sbom: true` on the `docker/build-push-action` step in the `polyglot-monorepo-stack` reusable workflow's `publish_apps` job.
- Attaches an SPDX SBOM attestation as an OCI referrer to every published app image, retrievable directly from GHCR, DockerHub, and GCP Artifact Registry.
- No consumer-repo changes required — the change is entirely contained in this reusable workflow.