### PR TITLE
feat(polyglot-monorepo-stack): expose Turbo remote cache to app Docker builds

### DIFF
--- a/workflows/polyglot-monorepo-stack/README.md
+++ b/workflows/polyglot-monorepo-stack/README.md
@@ -361,9 +361,7 @@ These are plain build arguments, not BuildKit secrets.
 **Example Dockerfile:**
 
 ```dockerfile
-# syntax=docker/dockerfile:1.4
-FROM node:22-alpine AS builder
-
+# ...inside your existing build stage
 ARG TURBO_API
 ARG TURBO_TEAM
 ARG TURBO_TOKEN

--- a/workflows/polyglot-monorepo-stack/README.md
+++ b/workflows/polyglot-monorepo-stack/README.md
@@ -342,6 +342,42 @@ RUN if [ -n "$uv_version" ]; then pip install uv==${uv_version}; fi
       npm config set //registry.npmjs.org/:_authToken $(cat /run/secrets/NPM_TOKEN)
   ```
 
+## Turbo Remote Cache in Docker Builds
+
+The `Setup Tools` step already used by app builds starts a runner-local Turborepo remote-cache proxy via [`rharkor/caching-for-turbo`](https://github.com/rharkor/caching-for-turbo) (through `setup-node`'s `enable-turbo-cache: auto`), backed by the GitHub Actions cache. The buildx builder is created with `network=host` and the build receives three additional build arguments pointing at that same proxy:
+
+- `TURBO_API` - URL of the runner-local cache proxy (host-reachable `127.0.0.1` address)
+- `TURBO_TEAM` - Team identifier expected by the proxy
+- `TURBO_TOKEN` - Session token of the proxy (local to the job, not a real credential)
+
+These are plain build arguments, not BuildKit secrets.
+
+**Consuming the cache is opt-in per app.** To use it, the app's `Dockerfile` must:
+
+1. Declare `# syntax=docker/dockerfile:1.4` (or newer) as its **first line**
+2. Accept the three build arguments via `ARG`/`ENV`
+3. Annotate the `turbo build` instruction with `--network=host`
+
+**Example Dockerfile:**
+
+```dockerfile
+# syntax=docker/dockerfile:1.4
+FROM node:22-alpine AS builder
+
+ARG TURBO_API
+ARG TURBO_TEAM
+ARG TURBO_TOKEN
+ENV TURBO_API=${TURBO_API}
+ENV TURBO_TEAM=${TURBO_TEAM}
+ENV TURBO_TOKEN=${TURBO_TOKEN}
+
+RUN --network=host turbo build
+```
+
+Without `--network=host` on the `RUN` instruction, the build cannot reach the proxy and Turbo falls back to a local-only cache.
+
+For Dockerfiles that don't reference these build arguments, this is a no-op: the extra arguments stay unused and the build behaves exactly as before.
+
 ## Migration from node-monorepo-stack
 
 To migrate from `node-monorepo-stack` to `polyglot-monorepo-stack`:

--- a/workflows/polyglot-monorepo-stack/README.md.hbs
+++ b/workflows/polyglot-monorepo-stack/README.md.hbs
@@ -349,9 +349,7 @@ These are plain build arguments, not BuildKit secrets.
 **Example Dockerfile:**
 
 ```dockerfile
-# syntax=docker/dockerfile:1.4
-FROM node:22-alpine AS builder
-
+# ...inside your existing build stage
 ARG TURBO_API
 ARG TURBO_TEAM
 ARG TURBO_TOKEN

--- a/workflows/polyglot-monorepo-stack/README.md.hbs
+++ b/workflows/polyglot-monorepo-stack/README.md.hbs
@@ -330,6 +330,42 @@ RUN if [ -n "$uv_version" ]; then pip install uv==${uv_version}; fi
       npm config set //registry.npmjs.org/:_authToken $(cat /run/secrets/NPM_TOKEN)
   ```
 
+## Turbo Remote Cache in Docker Builds
+
+The `Setup Tools` step already used by app builds starts a runner-local Turborepo remote-cache proxy via [`rharkor/caching-for-turbo`](https://github.com/rharkor/caching-for-turbo) (through `setup-node`'s `enable-turbo-cache: auto`), backed by the GitHub Actions cache. The buildx builder is created with `network=host` and the build receives three additional build arguments pointing at that same proxy:
+
+- `TURBO_API` - URL of the runner-local cache proxy (host-reachable `127.0.0.1` address)
+- `TURBO_TEAM` - Team identifier expected by the proxy
+- `TURBO_TOKEN` - Session token of the proxy (local to the job, not a real credential)
+
+These are plain build arguments, not BuildKit secrets.
+
+**Consuming the cache is opt-in per app.** To use it, the app's `Dockerfile` must:
+
+1. Declare `# syntax=docker/dockerfile:1.4` (or newer) as its **first line**
+2. Accept the three build arguments via `ARG`/`ENV`
+3. Annotate the `turbo build` instruction with `--network=host`
+
+**Example Dockerfile:**
+
+```dockerfile
+# syntax=docker/dockerfile:1.4
+FROM node:22-alpine AS builder
+
+ARG TURBO_API
+ARG TURBO_TEAM
+ARG TURBO_TOKEN
+ENV TURBO_API=${TURBO_API}
+ENV TURBO_TEAM=${TURBO_TEAM}
+ENV TURBO_TOKEN=${TURBO_TOKEN}
+
+RUN --network=host turbo build
+```
+
+Without `--network=host` on the `RUN` instruction, the build cannot reach the proxy and Turbo falls back to a local-only cache.
+
+For Dockerfiles that don't reference these build arguments, this is a no-op: the extra arguments stay unused and the build behaves exactly as before.
+
 ## Migration from node-monorepo-stack
 
 To migrate from `node-monorepo-stack` to `polyglot-monorepo-stack`:

--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -766,6 +766,9 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            network=host
 
       - name: Setup GCP Authentication
         if: inputs.enable-apps-registry-gcpar && inputs.gcp-auth != ''
@@ -839,6 +842,9 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
           echo "CACHE_FROM=$cache_from" >> $GITHUB_OUTPUT
           echo "CACHE_TO=$cache_to" >> $GITHUB_OUTPUT
+
+          # Turbo remote-cache passthrough
+          echo "TURBO_API=${TURBO_API/localhost/127.0.0.1}" >> $GITHUB_OUTPUT
           echo "Configured registries: ${#images[@]}"
 
       - name: Extract Docker metadata
@@ -918,8 +924,12 @@ jobs:
             uv_version=${{ steps.app-meta.outputs.UV_VERSION }}
             build_version=v${{ matrix.entry.version }}
             build_commit=${{ matrix.entry.sha }}
+            TURBO_API=${{ steps.image-names.outputs.TURBO_API }}
+            TURBO_TEAM=${{ env.TURBO_TEAM }}
+            TURBO_TOKEN=${{ env.TURBO_TOKEN }}
           secret-files: |
             ${{ steps.app-secrets.outputs.HAS_SECRETS == 'true' && steps.app-secrets.outputs.SECRETS_MOUNT_STRING || '' }}
+          allow: network.host
 
       - name: Display built image references
         run: |


### PR DESCRIPTION
## Summary
- Forward the runner-local Turborepo remote-cache proxy (already started by the existing `Setup Tools` step via `setup-node`'s `enable-turbo-cache: auto`) into each app's Docker image build in `publish_apps`.
- Enable `network=host` on the buildx builder and pass `TURBO_API` (rewritten to `127.0.0.1` for in-container reachability), `TURBO_TEAM`, and `TURBO_TOKEN` as plain build-args, plus `allow: network.host`.
- Consuming the cache stays opt-in per app: the app's own `Dockerfile` must use `# syntax=docker/dockerfile:1.4+`, accept the build-args via `ARG`/`ENV`, and annotate its `turbo build` RUN with `--network=host`. It's a no-op for Dockerfiles that don't reference them.
- Documents the new behavior in the workflow README.

## Test plan
- [x] `yaml.safe_load` validates `workflow.yaml`
- [x] `yarn check` passes (23/23 tasks, only pre-existing unrelated warnings)
- [x] `yarn readme:generate` regenerated README.md from the template with no drift
- [ ] End-to-end verification against a consumer app's Dockerfile that opts in (no Dockerfile lives in this repo to test directly)