### PR TITLE
fix(polyglot-monorepo-stack): grant actions:write for cache writes

### DIFF
--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -388,6 +388,9 @@ jobs:
     timeout-minutes: 10
     needs:
       - configure
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -428,6 +431,9 @@ jobs:
       fail-fast: false
       matrix:
         test-type: ${{ fromJSON(needs.configure.outputs.test-types-for-matrix) }}
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -512,6 +518,7 @@ jobs:
       contents: "write"
       id-token: "write"
       packages: "write"
+      actions: "write"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -647,6 +654,7 @@ jobs:
       contents: "read"
       id-token: "write"
       packages: "write"
+      actions: "write"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1113,6 +1121,7 @@ jobs:
       contents: read
       id-token: write
       pages: write
+      actions: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
GitHub Actions now requires the `actions: write` permission scope to save caches, which was causing `Setup Turbo cache` to fail with "Cache reservation failed: cache write denied: token has no writable scopes" in `polyglot-monorepo-stack` jobs.

Adds `actions: write` to the `check_build`, `test`, `publish_packages`, `publish_apps`, and `publish_gh_pages` jobs, all of which run `Setup Tools` (and therefore the Turbo/Yarn cache setup). `check_build` and `test` previously had no `permissions:` block, so an explicit `contents: read` was added alongside it to preserve checkout access.