### PR TITLE
fix(polyglot-monorepo-stack): support the pull_request trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,13 +6,14 @@ concurrency:
   # If it's not a PR or merge group, use 'main' as the PR number.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.event.merge_group.id || 'main' }}
   # Cancel only in-progress jobs when it's a PR.
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 on:
   push:
     branches:
       - main
-  pull_request_target:
+  # Not 'pull_request_target': its cache is read-only and it cannot check out fork PRs.
+  pull_request:
     branches:
       - main
 
@@ -27,7 +28,7 @@ jobs:
     steps:
       - name: Evaluate commit
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
               echo "PR is #${{ github.event.number }}..."
               echo "PR Head SHA is ${{ github.event.pull_request.head.sha }}..."
               echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
@@ -45,6 +46,10 @@ jobs:
     timeout-minutes: 5
     needs:
       - configure
+    permissions:
+      contents: read
+      packages: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/workflows/polyglot-monorepo-stack/README.md
+++ b/workflows/polyglot-monorepo-stack/README.md
@@ -1,417 +1,20 @@
 # polyglot-monorepo-stack
 
-Automate building, validation, and deployment for polyglot monorepos with an opinionated Yarn + Turborepo setup supporting multiple languages.
+CI/CD for Yarn + Turborepo monorepos that mix Node.js, Python and Go. It checks and builds the
+repository on every pull request, and on the default branch it also creates releases and publishes
+whatever the release contained: npm packages, container images, and GitOps deployment dispatches.
 
-This workflow provides a complete CI/CD pipeline for polyglot monorepos, handling:
+## Quick start
 
-- Dependency validation and build checks
-- Package publishing (for Node.js packages)
-- Image builds for deployable apps
-- GitHub Pages deployment for static apps
-
-## Makefile Requirements
-
-**This workflow requires a `Makefile`** with specific targets for dependency installation. This allows each repository to define its own installation strategy for multi-language setups.
-
-### Required Targets
-
-| Target              | Purpose                          | CI Usage          |
-| ------------------- | -------------------------------- | ----------------- |
-| `install`           | Install dependencies (dev)       | Local development |
-| `install-immutable` | Install with lockfile validation | CI/CD             |
-
-### Example: Node.js Only
-
-```makefile
-.PHONY: install install-immutable
-
-install:
-	yarn install
-
-install-immutable:
-	yarn install --immutable
-```
-
-### Example: Node.js + Python
-
-```makefile
-.PHONY: install install-immutable
-
-install:
-	yarn install
-	uv sync
-
-install-immutable:
-	yarn install --immutable
-	uv sync --frozen
-```
-
-### Example: Node.js + Python + Go
-
-```makefile
-.PHONY: install install-immutable
-
-install:
-	yarn install
-	uv sync
-	go mod download
-
-install-immutable:
-	yarn install --immutable
-	uv sync --frozen
-	go mod download && go mod verify
-```
-
-## Monorepo Requirements
-
-Your repository must follow this structure:
-
-### Package Manager & Build System
-
-- **Yarn (Berry)** - Package manager with workspaces support
-- **Turborepo** - Build system for monorepo orchestration and caching
-- **`.tool-versions`** - asdf version file (supports `nodejs`, `python`, `golang`, etc.)
-- **`Makefile`** - With `install` and `install-immutable` targets
-
-### Directory Structure
-
-```
-your-repo/
-├── Makefile              # Required: install and install-immutable targets
-├── .tool-versions        # Required: tool versions for setup-tools
-├── packages/             # Publishable packages (libraries, shared code)
-│   ├── package-a/        # Node.js package
-│   │   └── package.json
-│   ├── package-b/        # Python package (with package.json for monorepo integration)
-│   │   └── package.json
-│   └── package-c/        # Go package (with package.json for monorepo integration)
-│       └── package.json
-└── apps/                 # Deployable applications
-    ├── api/
-    │   ├── package.json
-    │   └── Dockerfile    # Required for Docker image builds
-    ├── worker/
-    │   ├── package.json
-    │   └── Dockerfile
-    └── docs/             # Static app for GitHub Pages (no Dockerfile needed)
-        └── package.json  # Must declare publishConfig.platform: "gh-pages"
-```
-
-**Validation Rules:**
-
-- **Packages**: Must contain a `package.json` file
-- **Docker apps**: Must contain both a `package.json` AND a `Dockerfile`
-- **Pages apps**: Must contain a `package.json` with `"publishConfig": { "platform": "gh-pages" }` — no `Dockerfile` required
-- **Private packages**: Packages with `"private": true` in package.json will not be published
-
-### Required Scripts
-
-Your root `package.json` must define these scripts:
-
-```json
-{
-  "scripts": {
-    "build": "turbo run build",
-    "check": "turbo run lint:check format:check"
-  }
-}
-```
-
-- **`build`** - Compiles all workspaces (packages and apps)
-- **`check`** - Runs linting and formatting validation across the monorepo
-
-## Package Language Tagging
-
-Packages declare their language in `package.json` under `publishConfig.language`. This determines whether the package is eligible for npm publishing.
-
-### Configuration
-
-```json
-{
-  "name": "@your-org/my-package",
-  "version": "1.0.0",
-  "publishConfig": {
-    "language": "nodejs",
-    "npm": true,
-    "ghpr": true
-  }
-}
-```
-
-### Supported Languages
-
-| Language      | Value      | npm Publishing                      |
-| ------------- | ---------- | ----------------------------------- |
-| Node.js       | `"nodejs"` | Yes (if configured)                 |
-| Python        | `"python"` | No (package.json for monorepo only) |
-| Go            | `"golang"` | No (package.json for monorepo only) |
-| Other         | Any string | No                                  |
-| Not specified | (missing)  | Yes (defaults to `"nodejs"`)        |
-
-### Why package.json for non-Node packages?
-
-Even Python/Go packages have a `package.json` to:
-
-- Integrate with Yarn/Turbo monorepo tooling
-- Define scripts (`build`, `test`, etc.)
-- Track version for release-please
-- Participate in workspace dependency graph
-
-### Example: Python Package
-
-```json
-{
-  "name": "@your-org/python-lib",
-  "version": "1.0.0",
-  "private": false,
-  "publishConfig": {
-    "language": "python"
-  },
-  "scripts": {
-    "build": "uv build",
-    "test": "pytest"
-  }
-}
-```
-
-### Example: Go Package
-
-```json
-{
-  "name": "@your-org/go-service",
-  "version": "1.0.0",
-  "private": false,
-  "publishConfig": {
-    "language": "golang"
-  },
-  "scripts": {
-    "build": "go build ./...",
-    "test": "go test ./..."
-  }
-}
-```
-
-## Package Publishing Configuration
-
-Node.js packages are published based on their `publishConfig` in `package.json`. The workflow reads these flags to determine which registries to publish to.
-
-### publishConfig Options
-
-```json
-{
-  "name": "@your-org/package-name",
-  "version": "1.0.0",
-  "private": false,
-  "publishConfig": {
-    "language": "nodejs",
-    "npm": true,
-    "ghpr": true,
-    "npmAccess": "public"
-  }
-}
-```
-
-**Available fields:**
-
-- **`language`** (string) - Package language: `"nodejs"`, `"python"`, `"golang"`, etc. (default: `"nodejs"`)
-- **`npm`** (boolean) - Publish to NPM registry (requires `enable-packages-registry-npm`; provenance is on by default via `enable-packages-registry-npm-provenance`)
-- **`ghpr`** (boolean) - Publish to GitHub Package Registry (requires `enable-packages-registry-ghpr`, uses `GITHUB_TOKEN`)
-- **`npmAccess`** (string) - Access level for NPM: `"public"` or `"restricted"` (default: `"public"`)
-
-**Important:**
-
-- Packages with `"private": true` are never published, regardless of `publishConfig`
-- Only packages with `"language": "nodejs"` (or no language specified) are eligible for npm publishing
-- GitHub Package Registry (ghpr) requires a scoped package name (e.g., `@your-org/package-name`)
-- Both workflow-level inputs AND package-level `publishConfig` must be enabled for publishing to occur
-
-### NPM Registry: Trusted Publishers & Provenance
-
-Publishing to the public NPM registry uses GitHub OIDC via [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers) — no `NPM_TOKEN` is required.
-
-**One-time setup per package on npmjs.com:**
-
-1. Go to the package's **Settings → Trusted Publishers** on npmjs.com.
-2. Add a GitHub Actions trusted publisher pointing at this reusable workflow:
-   - **Repository owner:** `abinnovision`
-   - **Repository name:** `actions`
-   - **Workflow filename:** `.github/workflows/workflow.yaml`
-   - **Environment:** _(leave empty)_
-3. Repeat for every package you publish to npmjs.org.
-
-**Provenance attestations** are generated by default (`enable-packages-registry-npm-provenance: true`). The published version will show a "Provenance" badge on npmjs.com linking back to the workflow run that built it. Disable the toggle if the package can't meet npm's provenance requirements (e.g. private packages).
-
-**Yarn version requirement:** Consumers must pin **Yarn ≥ 4.10.3** in `packageManager` — earlier Yarn versions don't implement the npm OIDC token exchange and the publish will fail authentication.
-
-## GitHub Pages Deployment
-
-Static apps can be deployed to GitHub Pages on each release by declaring `"platform": "gh-pages"` in the app's `publishConfig`. This opt-in convention is consistent with the `publishConfig.language` pattern used for packages.
-
-**Constraints:**
-
-- **One per repository** — only one app may declare `platform: "gh-pages"`. The `configure` job fails immediately if multiple apps are detected, preventing ambiguous release tracking.
-- **Release-gated** — deploys only when the app is part of a release (same gate as Docker image builds). Every Pages URL always reflects a tagged version.
-- **`github-pages` environment required** — the repository must have a `github-pages` environment configured in Settings → Environments, and GitHub Pages must be enabled for the repo.
-
-### App Configuration
-
-```json
-{
-  "name": "@your-org/docs",
-  "version": "1.0.0",
-  "publishConfig": {
-    "platform": "gh-pages"
-  },
-  "scripts": {
-    "build": "vitepress build"
-  }
-}
-```
-
-The workflow runs `turbo build --filter=./apps/<app>` and copies the contents of the build output directory (default: `dist`) to the Pages artifact. Set `gh-pages-build-output` if your tool writes to a different directory.
-
-### Enabling in Your Workflow
+Add the trigger block and the job to `.github/workflows/build.yaml`:
 
 ```yaml
-jobs:
-  polyglot-monorepo-stack:
-    uses: abinnovision/actions/.github/workflows/workflow.yaml@polyglot-monorepo-stack-v1
-    secrets: inherit
-    with:
-      enable-gh-pages: true
-      # Optional: override if your build outputs to a different directory
-      gh-pages-build-output: out
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 ```
-
-### Repository Setup
-
-1. Go to **Settings → Pages** and set the source to **GitHub Actions**.
-2. Go to **Settings → Environments** and create an environment named **`github-pages`**.
-
-## Docker Build Details
-
-**Automatic Turbo Prune:**
-
-- The workflow runs `turbo prune --docker` before building images
-- Creates optimized structure in `out/{app-name}/` with `json/` (package files) and `full/` (source)
-- Requires Turbo in root `package.json` and package `name` field in each app's `package.json`
-
-**Available Build Arguments:**
-
-- `app_name` - Application name from directory
-- `node_version` - Node.js version from `.tool-versions` (required)
-- `python_version` - Python version from `.tool-versions` (optional)
-- `golang_version` - Go version from `.tool-versions` (optional)
-- `uv_version` - UV version from `.tool-versions` (optional)
-- `build_version` - Semantic version with commit (e.g., `v1.2.3-abc1234`)
-- `build_commit` - Full commit SHA
-
-**Example Dockerfile using multiple language versions:**
-
-```dockerfile
-ARG node_version
-ARG python_version
-ARG uv_version
-
-FROM node:${node_version}-alpine AS node-builder
-# ... Node.js build steps
-
-FROM python:${python_version}-slim AS python-builder
-# Install UV if version provided
-ARG uv_version
-RUN if [ -n "$uv_version" ]; then pip install uv==${uv_version}; fi
-# ... Python build steps
-```
-
-**App-Specific Secrets:**
-
-- Apps can have build-time secrets via the `APP_IMAGE_SECRETS` GitHub secret
-- Use CSV format with structure: `app-name,secret-name,secret-value` (one per line)
-- Example:
-  ```
-  api,NPM_TOKEN,npm_abc123xyz
-  api,SENTRY_TOKEN,abc123
-  frontend,API_KEY,secret-value
-  ```
-- Each secret is available as an individual BuildKit secret mount in your Dockerfile
-- Access secrets using: `--mount=type=secret,id=SECRET_NAME`
-- Secrets are mounted at `/run/secrets/SECRET_NAME` and are not stored in image layers
-- **Example Dockerfile usage:**
-  ```dockerfile
-  RUN --mount=type=secret,id=NPM_TOKEN \
-      npm config set //registry.npmjs.org/:_authToken $(cat /run/secrets/NPM_TOKEN)
-  ```
-
-## Turbo Remote Cache in Docker Builds
-
-The `Setup Tools` step already used by app builds starts a runner-local Turborepo remote-cache proxy via [`rharkor/caching-for-turbo`](https://github.com/rharkor/caching-for-turbo) (through `setup-node`'s `enable-turbo-cache: auto`), backed by the GitHub Actions cache. The buildx builder is created with `network=host` and the build receives three additional build arguments pointing at that same proxy:
-
-- `TURBO_API` - URL of the runner-local cache proxy (host-reachable `127.0.0.1` address)
-- `TURBO_TEAM` - Team identifier expected by the proxy
-- `TURBO_TOKEN` - Session token of the proxy (local to the job, not a real credential)
-
-These are plain build arguments, not BuildKit secrets.
-
-**Consuming the cache is opt-in per app.** To use it, the app's `Dockerfile` must:
-
-1. Declare `# syntax=docker/dockerfile:1.4` (or newer) as its **first line**
-2. Accept the three build arguments via `ARG`/`ENV`
-3. Annotate the `turbo build` instruction with `--network=host`
-
-**Example Dockerfile:**
-
-```dockerfile
-# ...inside your existing build stage
-ARG TURBO_API
-ARG TURBO_TEAM
-ARG TURBO_TOKEN
-ENV TURBO_API=${TURBO_API}
-ENV TURBO_TEAM=${TURBO_TEAM}
-ENV TURBO_TOKEN=${TURBO_TOKEN}
-
-RUN --network=host turbo build
-```
-
-Without `--network=host` on the `RUN` instruction, the build cannot reach the proxy and Turbo falls back to a local-only cache.
-
-For Dockerfiles that don't reference these build arguments, this is a no-op: the extra arguments stay unused and the build behaves exactly as before.
-
-## Migration from node-monorepo-stack
-
-To migrate from `node-monorepo-stack` to `polyglot-monorepo-stack`:
-
-1. **Create a Makefile** in your repository root:
-
-   ```makefile
-   .PHONY: install install-immutable
-
-   install:
-   	yarn install
-
-   install-immutable:
-   	yarn install --immutable
-   ```
-
-2. **Update your workflow reference**:
-
-   ```yaml
-   # Before
-   uses: abinnovision/actions/.github/workflows/workflow.yaml@node-monorepo-stack-v1
-
-   # After
-   uses: abinnovision/actions/.github/workflows/workflow.yaml@polyglot-monorepo-stack-v1
-   ```
-
-3. **(Optional) Tag packages with languages** if you have non-Node.js packages:
-   ```json
-   {
-     "publishConfig": {
-       "language": "python"
-     }
-   }
-   ```
-
-## Usage
 
 [//]: # "x-release-please-start-major"
 
@@ -423,7 +26,312 @@ jobs:
 
 [//]: # "x-release-please-end"
 
-## Latest versions
+Add `secrets: inherit` to the job if you use any of the optional [secrets](#secrets), such as a
+custom checkout token or per-app image build secrets.
+
+The repository must also meet the [layout requirements](#repository-layout). Everything beyond that
+is opt-in through [inputs](#inputs).
+
+## Triggers
+
+| Event                        | Runs                                      | Actions cache                                                      |
+| ---------------------------- | ----------------------------------------- | ------------------------------------------------------------------ |
+| `pull_request`               | `configure`, `check_build`, `test`        | Read/write in the PR scope, restores from the default branch       |
+| `merge_group`                | `configure`, `check_build`, `test`        | Read/write in the queue scope, restores from the default branch    |
+| `push` to the default branch | everything, including release and publish | Read/write in the default branch scope, the cache PRs restore from |
+
+Releasing and publishing are gated inside the workflow on `push` to `default-branch`, so a pull
+request can never reach them regardless of how it was triggered.
+
+`merge_group` is optional and only fires when a merge queue is enabled on the branch. If you use
+one, add it to the trigger block:
+
+```yaml
+merge_group:
+  types: [checks_requested]
+```
+
+### Concurrency
+
+Declare concurrency in the calling workflow. A called workflow sees the caller's `github.workflow`,
+so declaring a group on both sides collides and GitHub cancels the run as a deadlock. Use:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.event.merge_group.id || 'main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+```
+
+Pull requests and merge groups supersede themselves; pushes to the default branch queue instead, so
+no release or publish is ever cut short.
+
+### Permissions
+
+The jobs request `contents: read`, `packages: read` and `actions: write`, plus `contents: write`,
+`packages: write`, `id-token: write` and `pages: write` in the publishing jobs. `actions: write` is
+what the Actions cache service requires to save entries.
+
+A called workflow can never exceed its caller's permissions. The calling repository must therefore
+either keep the default "Read and write permissions" setting for `GITHUB_TOKEN`, or declare a
+top-level `permissions:` block that covers those scopes.
+
+### Forks and Dependabot
+
+Pull requests from forks get a read-only token that the `permissions:` key cannot elevate. Cache
+saves are skipped with a warning, `CHECKOUT_TOKEN` is empty so private submodules do not resolve,
+and private GitHub Package Registry dependencies are unavailable. Those runs restore the default
+branch cache instead of writing their own.
+
+Dependabot pull requests do honour the `permissions:` key and keep cache writes. They see Dependabot
+secrets rather than Actions secrets, which the pull request lane does not need.
+
+## Repository layout
+
+### Makefile
+
+Dependency installation goes through `make`, so each repository can define its own strategy across
+languages. Two targets are required; `configure` fails the run if `install-immutable` is missing.
+
+| Target              | Purpose                          | Used by           |
+| ------------------- | -------------------------------- | ----------------- |
+| `install`           | Install dependencies             | Local development |
+| `install-immutable` | Install with lockfile validation | CI                |
+
+```makefile
+.PHONY: install install-immutable
+
+install:
+	yarn install
+	uv sync              # only if the repo has Python packages
+	go mod download      # only if the repo has Go packages
+
+install-immutable:
+	yarn install --immutable
+	uv sync --frozen
+	go mod download && go mod verify
+```
+
+### Directory structure
+
+```
+your-repo/
+├── Makefile              # install and install-immutable targets
+├── .tool-versions        # asdf versions: nodejs (required), python, golang, uv
+├── packages/             # publishable libraries and shared code
+│   └── <name>/package.json
+└── apps/                 # deployable applications
+    ├── <name>/
+    │   ├── package.json
+    │   └── Dockerfile    # required for container image builds
+    └── <docs>/package.json   # gh-pages apps need no Dockerfile
+```
+
+The `configure` job discovers workspaces by these rules:
+
+- A directory under `packages/` counts as a package if it has a `package.json`.
+- A directory under `apps/` counts as an image-buildable app if it has both a `package.json` and a
+  `Dockerfile`.
+- An app is a Pages app if its `package.json` declares `"publishConfig": { "platform": "gh-pages" }`.
+- Packages marked `"private": true` are never published.
+
+### Root scripts
+
+Your root `package.json` must define:
+
+```json
+{
+  "scripts": {
+    "build": "turbo run build",
+    "check": "turbo run lint:check format:check",
+    "test-unit": "turbo run test-unit"
+  }
+}
+```
+
+`build` compiles every workspace and `check` runs linting and formatting. Each entry in `test-types`
+needs a matching `test-<type>` script, so enabling `test-types: unit,integration` requires both
+`test-unit` and `test-integration`.
+
+## Pipeline
+
+| Job           | When                                                                             |
+| ------------- | -------------------------------------------------------------------------------- |
+| `configure`   | Always. Resolves the commit, validates the Makefile, discovers workspaces        |
+| `check_build` | Always. `install-immutable`, dependency checks, `check`, `build`, and unit tests |
+| `test`        | One parallel job per test type not already covered by `check_build`              |
+| `release`     | Push to the default branch only. Creates or lands release PRs                    |
+| `publish_*`   | Only for workspaces the release actually versioned                               |
+
+Unit tests run inside `check_build` by default rather than as their own job, which avoids a second
+install and build. Set `run-unit-tests-in-build: false` to move them into the `test` matrix.
+
+If your linter or formatter config lives in a workspace package that has to be compiled first, set
+`run-build-before-check: true`. The order then becomes install, dependency check, build, check,
+unit tests.
+
+## Publishing packages
+
+Enable with `enable-package-publishing`, then enable at least one registry
+(`enable-packages-registry-npm`, `enable-packages-registry-ghpr`). Both the workflow input and the
+package's own `publishConfig` must agree before anything is published.
+
+```json
+{
+  "name": "@your-org/package-name",
+  "version": "1.0.0",
+  "publishConfig": {
+    "language": "nodejs",
+    "npm": true,
+    "ghpr": true,
+    "npmAccess": "public"
+  }
+}
+```
+
+| Field       | Meaning                                                           |
+| ----------- | ----------------------------------------------------------------- |
+| `language`  | `nodejs`, `python`, `golang`, or any string. Defaults to `nodejs` |
+| `npm`       | Publish to the public npm registry                                |
+| `ghpr`      | Publish to the GitHub Package Registry. Requires a scoped name    |
+| `npmAccess` | `public` or `restricted`. Defaults to `public`                    |
+
+Only packages resolving to `nodejs` are published. Python and Go packages still carry a
+`package.json` so they participate in the Yarn workspace graph, Turbo's task scheduling and
+release-please versioning, but the publish step skips them and their real artifacts are built by
+their own toolchain.
+
+### npm trusted publishers
+
+Publishing to npmjs.com uses GitHub OIDC through
+[trusted publishers](https://docs.npmjs.com/trusted-publishers), so no `NPM_TOKEN` is involved. Each
+package needs a one-time setup on npmjs.com under Settings → Trusted Publishers: add a GitHub Actions
+publisher with owner `abinnovision`, repository `actions`, workflow filename
+`.github/workflows/workflow.yaml`, and no environment.
+
+This requires Yarn 4.10.3 or newer in your `packageManager` field. Earlier versions do not implement
+the npm OIDC token exchange and authentication fails.
+
+Provenance attestations are generated by default and show up as a badge on npmjs.com linking back to
+the run that built the version. Turn `enable-packages-registry-npm-provenance` off for packages that
+cannot meet npm's provenance requirements.
+
+## Publishing container images
+
+Enable with `enable-app-image-builds` plus at least one of `enable-apps-registry-ghcr`,
+`enable-apps-registry-dockerhub` or `enable-apps-registry-gcpar`. Images are built only for apps
+that the release actually versioned, and each image is tagged with both its commit SHA and its
+semantic version.
+
+Before building, the workflow runs `turbo prune --docker` for the app and builds from the pruned
+tree in `out/<app-name>/`, which contains a `json/` directory with package manifests and a `full/`
+directory with sources. Turbo must be a dependency in the root `package.json` and every app needs a
+`name` in its `package.json`.
+
+### Build arguments
+
+| Argument         | Source                                         |
+| ---------------- | ---------------------------------------------- |
+| `app_name`       | App directory name                             |
+| `node_version`   | `.tool-versions`, required                     |
+| `python_version` | `.tool-versions`, optional                     |
+| `golang_version` | `.tool-versions`, optional                     |
+| `uv_version`     | `.tool-versions`, optional                     |
+| `build_version`  | Semantic version with commit, `v1.2.3-abc1234` |
+| `build_commit`   | Full commit SHA                                |
+
+```dockerfile
+ARG node_version
+ARG python_version
+
+FROM node:${node_version}-alpine AS node-builder
+FROM python:${python_version}-slim AS python-builder
+```
+
+### Build secrets
+
+Per-app build-time secrets come from the `APP_IMAGE_SECRETS` secret, in CSV format, one per line:
+
+```
+api,NPM_TOKEN,npm_abc123xyz
+api,SENTRY_TOKEN,abc123
+frontend,API_KEY,secret,with,commas,is,fine
+```
+
+Only the first two commas are delimiters, so values may contain commas. Each entry becomes its own
+BuildKit secret mount, available at `/run/secrets/<name>` and never written to an image layer:
+
+```dockerfile
+RUN --mount=type=secret,id=NPM_TOKEN \
+    npm config set //registry.npmjs.org/:_authToken $(cat /run/secrets/NPM_TOKEN)
+```
+
+### Turbo remote cache inside the build
+
+`Setup Tools` starts a runner-local Turborepo cache proxy backed by the Actions cache. The buildx
+builder runs with `network=host` and the build receives `TURBO_API`, `TURBO_TEAM` and `TURBO_TOKEN`
+pointing at that proxy. These are plain build arguments rather than BuildKit secrets; the token is a
+session identifier for the local proxy, not a credential.
+
+Using them is opt-in per app. The `Dockerfile` must declare `# syntax=docker/dockerfile:1.4` or newer
+as its first line, accept the three arguments, and mark the build instruction `--network=host`:
+
+```dockerfile
+ARG TURBO_API
+ARG TURBO_TEAM
+ARG TURBO_TOKEN
+ENV TURBO_API=${TURBO_API}
+ENV TURBO_TEAM=${TURBO_TEAM}
+ENV TURBO_TOKEN=${TURBO_TOKEN}
+
+RUN --network=host turbo build
+```
+
+Without `--network=host` the build cannot reach the proxy and Turbo silently falls back to a
+local-only cache. Dockerfiles that ignore these arguments are unaffected.
+
+## Publishing to GitHub Pages
+
+A static app opts in by declaring `"publishConfig": { "platform": "gh-pages" }`, matching the
+`publishConfig.language` convention used by packages. Set `enable-gh-pages: true` on the workflow,
+and `gh-pages-build-output` if the build writes somewhere other than `dist`.
+
+```json
+{
+  "name": "@your-org/docs",
+  "publishConfig": { "platform": "gh-pages" },
+  "scripts": { "build": "vitepress build" }
+}
+```
+
+Only one app per repository may declare the platform. `configure` fails immediately if it finds more,
+since release tracking would otherwise be ambiguous. Deployment is gated on the app being part of a
+release, and prereleases are excluded, so the published site always reflects a tagged version. The
+repository also needs Pages enabled with GitHub Actions as the source, plus a `github-pages`
+environment under Settings → Environments.
+
+## Dispatching GitOps updates
+
+After images are published, the workflow can trigger a deployment workflow in a GitOps repository.
+Configure it with `gitops-app-config` in CSV format, one line per app:
+
+```
+app-name,target-repo,dev-application,release-application,registry,image-name
+```
+
+Only the first five commas are delimiters. A `target-repo` without a slash is resolved against the
+current repository owner. Valid registries are `ghcr`, `gcpar` and `dockerhub`. Apps with incomplete
+rows are skipped with a warning.
+
+Releases dispatch against `release-application` and prereleases against `dev-application`. Apps
+sharing a target repository and application are batched into one dispatch, and the dispatch only
+happens if every image in the release was published, so a partial release never reaches your
+cluster.
+
+This requires `token-broker-url` (or the `TOKEN_BROKER_URL` repository variable), which the workflow
+uses to exchange an OIDC token for one scoped to the target repositories. The dispatched workflow
+defaults to `update-tags.yaml` and receives `application` and `updates` inputs.
+
+## Versions
 
 This workflow can be used with different version ranges. The following ranges are available:
 

--- a/workflows/polyglot-monorepo-stack/README.md.hbs
+++ b/workflows/polyglot-monorepo-stack/README.md.hbs
@@ -1,59 +1,101 @@
 # {{name}}
 
-Automate building, validation, and deployment for polyglot monorepos with an opinionated Yarn + Turborepo setup supporting multiple languages.
+CI/CD for Yarn + Turborepo monorepos that mix Node.js, Python and Go. It checks and builds the
+repository on every pull request, and on the default branch it also creates releases and publishes
+whatever the release contained: npm packages, container images, and GitOps deployment dispatches.
 
-This workflow provides a complete CI/CD pipeline for polyglot monorepos, handling:
-- Dependency validation and build checks
-- Package publishing (for Node.js packages)
-- Image builds for deployable apps
-- GitHub Pages deployment for static apps
+## Quick start
 
-## Makefile Requirements
+Add the trigger block and the job to `.github/workflows/build.yaml`:
 
-**This workflow requires a `Makefile`** with specific targets for dependency installation. This allows each repository to define its own installation strategy for multi-language setups.
-
-### Required Targets
-
-| Target | Purpose | CI Usage |
-|--------|---------|----------|
-| `install` | Install dependencies (dev) | Local development |
-| `install-immutable` | Install with lockfile validation | CI/CD |
-
-### Example: Node.js Only
-
-```makefile
-.PHONY: install install-immutable
-
-install:
-	yarn install
-
-install-immutable:
-	yarn install --immutable
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 ```
 
-### Example: Node.js + Python
+{{{usage-example type="workflow" name=name inputs=inputs secrets=secrets version=version}}}
 
-```makefile
-.PHONY: install install-immutable
+Add `secrets: inherit` to the job if you use any of the optional [secrets](#secrets), such as a
+custom checkout token or per-app image build secrets.
 
-install:
-	yarn install
-	uv sync
+The repository must also meet the [layout requirements](#repository-layout). Everything beyond that
+is opt-in through [inputs](#inputs).
 
-install-immutable:
-	yarn install --immutable
-	uv sync --frozen
+## Triggers
+
+| Event                          | Runs                                   | Actions cache                                                     |
+| ------------------------------ | -------------------------------------- | ----------------------------------------------------------------- |
+| `pull_request`                 | `configure`, `check_build`, `test`      | Read/write in the PR scope, restores from the default branch       |
+| `merge_group`                  | `configure`, `check_build`, `test`      | Read/write in the queue scope, restores from the default branch    |
+| `push` to the default branch   | everything, including release and publish | Read/write in the default branch scope, the cache PRs restore from |
+
+Releasing and publishing are gated inside the workflow on `push` to `default-branch`, so a pull
+request can never reach them regardless of how it was triggered.
+
+`merge_group` is optional and only fires when a merge queue is enabled on the branch. If you use
+one, add it to the trigger block:
+
+```yaml
+merge_group:
+  types: [checks_requested]
 ```
 
-### Example: Node.js + Python + Go
+### Concurrency
+
+Declare concurrency in the calling workflow. A called workflow sees the caller's `github.workflow`,
+so declaring a group on both sides collides and GitHub cancels the run as a deadlock. Use:
+
+```yaml
+concurrency:
+  group: $\{{ github.workflow }}-$\{{ github.ref }}-$\{{ github.event.pull_request.number || github.event.merge_group.id || 'main' }}
+  cancel-in-progress: $\{{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+```
+
+Pull requests and merge groups supersede themselves; pushes to the default branch queue instead, so
+no release or publish is ever cut short.
+
+### Permissions
+
+The jobs request `contents: read`, `packages: read` and `actions: write`, plus `contents: write`,
+`packages: write`, `id-token: write` and `pages: write` in the publishing jobs. `actions: write` is
+what the Actions cache service requires to save entries.
+
+A called workflow can never exceed its caller's permissions. The calling repository must therefore
+either keep the default "Read and write permissions" setting for `GITHUB_TOKEN`, or declare a
+top-level `permissions:` block that covers those scopes.
+
+### Forks and Dependabot
+
+Pull requests from forks get a read-only token that the `permissions:` key cannot elevate. Cache
+saves are skipped with a warning, `CHECKOUT_TOKEN` is empty so private submodules do not resolve,
+and private GitHub Package Registry dependencies are unavailable. Those runs restore the default
+branch cache instead of writing their own.
+
+Dependabot pull requests do honour the `permissions:` key and keep cache writes. They see Dependabot
+secrets rather than Actions secrets, which the pull request lane does not need.
+
+## Repository layout
+
+### Makefile
+
+Dependency installation goes through `make`, so each repository can define its own strategy across
+languages. Two targets are required; `configure` fails the run if `install-immutable` is missing.
+
+| Target              | Purpose                               | Used by         |
+| ------------------- | ------------------------------------- | --------------- |
+| `install`           | Install dependencies                  | Local development |
+| `install-immutable` | Install with lockfile validation      | CI                |
 
 ```makefile
 .PHONY: install install-immutable
 
 install:
 	yarn install
-	uv sync
-	go mod download
+	uv sync              # only if the repo has Python packages
+	go mod download      # only if the repo has Go packages
 
 install-immutable:
 	yarn install --immutable
@@ -61,143 +103,74 @@ install-immutable:
 	go mod download && go mod verify
 ```
 
-## Monorepo Requirements
-
-Your repository must follow this structure:
-
-### Package Manager & Build System
-- **Yarn (Berry)** - Package manager with workspaces support
-- **Turborepo** - Build system for monorepo orchestration and caching
-- **`.tool-versions`** - asdf version file (supports `nodejs`, `python`, `golang`, etc.)
-- **`Makefile`** - With `install` and `install-immutable` targets
-
-### Directory Structure
+### Directory structure
 
 ```
 your-repo/
-├── Makefile              # Required: install and install-immutable targets
-├── .tool-versions        # Required: tool versions for setup-tools
-├── packages/             # Publishable packages (libraries, shared code)
-│   ├── package-a/        # Node.js package
-│   │   └── package.json
-│   ├── package-b/        # Python package (with package.json for monorepo integration)
-│   │   └── package.json
-│   └── package-c/        # Go package (with package.json for monorepo integration)
-│       └── package.json
-└── apps/                 # Deployable applications
-    ├── api/
+├── Makefile              # install and install-immutable targets
+├── .tool-versions        # asdf versions: nodejs (required), python, golang, uv
+├── packages/             # publishable libraries and shared code
+│   └── <name>/package.json
+└── apps/                 # deployable applications
+    ├── <name>/
     │   ├── package.json
-    │   └── Dockerfile    # Required for Docker image builds
-    ├── worker/
-    │   ├── package.json
-    │   └── Dockerfile
-    └── docs/             # Static app for GitHub Pages (no Dockerfile needed)
-        └── package.json  # Must declare publishConfig.platform: "gh-pages"
+    │   └── Dockerfile    # required for container image builds
+    └── <docs>/package.json   # gh-pages apps need no Dockerfile
 ```
 
-**Validation Rules:**
-- **Packages**: Must contain a `package.json` file
-- **Docker apps**: Must contain both a `package.json` AND a `Dockerfile`
-- **Pages apps**: Must contain a `package.json` with `"publishConfig": { "platform": "gh-pages" }` — no `Dockerfile` required
-- **Private packages**: Packages with `"private": true` in package.json will not be published
+The `configure` job discovers workspaces by these rules:
 
-### Required Scripts
+- A directory under `packages/` counts as a package if it has a `package.json`.
+- A directory under `apps/` counts as an image-buildable app if it has both a `package.json` and a
+  `Dockerfile`.
+- An app is a Pages app if its `package.json` declares `"publishConfig": { "platform": "gh-pages" }`.
+- Packages marked `"private": true` are never published.
 
-Your root `package.json` must define these scripts:
+### Root scripts
+
+Your root `package.json` must define:
 
 ```json
 {
-"scripts": {
-"build": "turbo run build",
-"check": "turbo run lint:check format:check"
-}
-}
-```
-
-- **`build`** - Compiles all workspaces (packages and apps)
-- **`check`** - Runs linting and formatting validation across the monorepo
-
-## Package Language Tagging
-
-Packages declare their language in `package.json` under `publishConfig.language`. This determines whether the package is eligible for npm publishing.
-
-### Configuration
-
-```json
-{
-  "name": "@your-org/my-package",
-  "version": "1.0.0",
-  "publishConfig": {
-    "language": "nodejs",
-    "npm": true,
-    "ghpr": true
-  }
-}
-```
-
-### Supported Languages
-
-| Language | Value | npm Publishing |
-|----------|-------|----------------|
-| Node.js | `"nodejs"` | Yes (if configured) |
-| Python | `"python"` | No (package.json for monorepo only) |
-| Go | `"golang"` | No (package.json for monorepo only) |
-| Other | Any string | No |
-| Not specified | (missing) | Yes (defaults to `"nodejs"`) |
-
-### Why package.json for non-Node packages?
-
-Even Python/Go packages have a `package.json` to:
-- Integrate with Yarn/Turbo monorepo tooling
-- Define scripts (`build`, `test`, etc.)
-- Track version for release-please
-- Participate in workspace dependency graph
-
-### Example: Python Package
-
-```json
-{
-  "name": "@your-org/python-lib",
-  "version": "1.0.0",
-  "private": false,
-  "publishConfig": {
-    "language": "python"
-  },
   "scripts": {
-    "build": "uv build",
-    "test": "pytest"
+    "build": "turbo run build",
+    "check": "turbo run lint:check format:check",
+    "test-unit": "turbo run test-unit"
   }
 }
 ```
 
-### Example: Go Package
+`build` compiles every workspace and `check` runs linting and formatting. Each entry in `test-types`
+needs a matching `test-<type>` script, so enabling `test-types: unit,integration` requires both
+`test-unit` and `test-integration`.
 
-```json
-{
-  "name": "@your-org/go-service",
-  "version": "1.0.0",
-  "private": false,
-  "publishConfig": {
-    "language": "golang"
-  },
-  "scripts": {
-    "build": "go build ./...",
-    "test": "go test ./..."
-  }
-}
-```
+## Pipeline
 
-## Package Publishing Configuration
+| Job             | When                                                      |
+| --------------- | --------------------------------------------------------- |
+| `configure`     | Always. Resolves the commit, validates the Makefile, discovers workspaces |
+| `check_build`   | Always. `install-immutable`, dependency checks, `check`, `build`, and unit tests |
+| `test`          | One parallel job per test type not already covered by `check_build` |
+| `release`       | Push to the default branch only. Creates or lands release PRs |
+| `publish_*`     | Only for workspaces the release actually versioned         |
 
-Node.js packages are published based on their `publishConfig` in `package.json`. The workflow reads these flags to determine which registries to publish to.
+Unit tests run inside `check_build` by default rather than as their own job, which avoids a second
+install and build. Set `run-unit-tests-in-build: false` to move them into the `test` matrix.
 
-### publishConfig Options
+If your linter or formatter config lives in a workspace package that has to be compiled first, set
+`run-build-before-check: true`. The order then becomes install, dependency check, build, check,
+unit tests.
+
+## Publishing packages
+
+Enable with `enable-package-publishing`, then enable at least one registry
+(`enable-packages-registry-npm`, `enable-packages-registry-ghpr`). Both the workflow input and the
+package's own `publishConfig` must agree before anything is published.
 
 ```json
 {
   "name": "@your-org/package-name",
   "version": "1.0.0",
-  "private": false,
   "publishConfig": {
     "language": "nodejs",
     "npm": true,
@@ -207,149 +180,94 @@ Node.js packages are published based on their `publishConfig` in `package.json`.
 }
 ```
 
-**Available fields:**
-- **`language`** (string) - Package language: `"nodejs"`, `"python"`, `"golang"`, etc. (default: `"nodejs"`)
-- **`npm`** (boolean) - Publish to NPM registry (requires `enable-packages-registry-npm`; provenance is on by default via `enable-packages-registry-npm-provenance`)
-- **`ghpr`** (boolean) - Publish to GitHub Package Registry (requires `enable-packages-registry-ghpr`, uses `GITHUB_TOKEN`)
-- **`npmAccess`** (string) - Access level for NPM: `"public"` or `"restricted"` (default: `"public"`)
+| Field        | Meaning                                                                       |
+| ------------ | ----------------------------------------------------------------------------- |
+| `language`   | `nodejs`, `python`, `golang`, or any string. Defaults to `nodejs`              |
+| `npm`        | Publish to the public npm registry                                            |
+| `ghpr`       | Publish to the GitHub Package Registry. Requires a scoped name                |
+| `npmAccess`  | `public` or `restricted`. Defaults to `public`                                |
 
-**Important:**
-- Packages with `"private": true` are never published, regardless of `publishConfig`
-- Only packages with `"language": "nodejs"` (or no language specified) are eligible for npm publishing
-- GitHub Package Registry (ghpr) requires a scoped package name (e.g., `@your-org/package-name`)
-- Both workflow-level inputs AND package-level `publishConfig` must be enabled for publishing to occur
+Only packages resolving to `nodejs` are published. Python and Go packages still carry a
+`package.json` so they participate in the Yarn workspace graph, Turbo's task scheduling and
+release-please versioning, but the publish step skips them and their real artifacts are built by
+their own toolchain.
 
-### NPM Registry: Trusted Publishers & Provenance
+### npm trusted publishers
 
-Publishing to the public NPM registry uses GitHub OIDC via [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers) — no `NPM_TOKEN` is required.
+Publishing to npmjs.com uses GitHub OIDC through
+[trusted publishers](https://docs.npmjs.com/trusted-publishers), so no `NPM_TOKEN` is involved. Each
+package needs a one-time setup on npmjs.com under Settings → Trusted Publishers: add a GitHub Actions
+publisher with owner `abinnovision`, repository `actions`, workflow filename
+`.github/workflows/workflow.yaml`, and no environment.
 
-**One-time setup per package on npmjs.com:**
-1. Go to the package's **Settings → Trusted Publishers** on npmjs.com.
-2. Add a GitHub Actions trusted publisher pointing at this reusable workflow:
-   - **Repository owner:** `abinnovision`
-   - **Repository name:** `actions`
-   - **Workflow filename:** `.github/workflows/workflow.yaml`
-   - **Environment:** *(leave empty)*
-3. Repeat for every package you publish to npmjs.org.
+This requires Yarn 4.10.3 or newer in your `packageManager` field. Earlier versions do not implement
+the npm OIDC token exchange and authentication fails.
 
-**Provenance attestations** are generated by default (`enable-packages-registry-npm-provenance: true`). The published version will show a "Provenance" badge on npmjs.com linking back to the workflow run that built it. Disable the toggle if the package can't meet npm's provenance requirements (e.g. private packages).
+Provenance attestations are generated by default and show up as a badge on npmjs.com linking back to
+the run that built the version. Turn `enable-packages-registry-npm-provenance` off for packages that
+cannot meet npm's provenance requirements.
 
-**Yarn version requirement:** Consumers must pin **Yarn ≥ 4.10.3** in `packageManager` — earlier Yarn versions don't implement the npm OIDC token exchange and the publish will fail authentication.
+## Publishing container images
 
-## GitHub Pages Deployment
+Enable with `enable-app-image-builds` plus at least one of `enable-apps-registry-ghcr`,
+`enable-apps-registry-dockerhub` or `enable-apps-registry-gcpar`. Images are built only for apps
+that the release actually versioned, and each image is tagged with both its commit SHA and its
+semantic version.
 
-Static apps can be deployed to GitHub Pages on each release by declaring `"platform": "gh-pages"` in the app's `publishConfig`. This opt-in convention is consistent with the `publishConfig.language` pattern used for packages.
+Before building, the workflow runs `turbo prune --docker` for the app and builds from the pruned
+tree in `out/<app-name>/`, which contains a `json/` directory with package manifests and a `full/`
+directory with sources. Turbo must be a dependency in the root `package.json` and every app needs a
+`name` in its `package.json`.
 
-**Constraints:**
-- **One per repository** — only one app may declare `platform: "gh-pages"`. The `configure` job fails immediately if multiple apps are detected, preventing ambiguous release tracking.
-- **Release-gated** — deploys only when the app is part of a release (same gate as Docker image builds). Every Pages URL always reflects a tagged version.
-- **`github-pages` environment required** — the repository must have a `github-pages` environment configured in Settings → Environments, and GitHub Pages must be enabled for the repo.
+### Build arguments
 
-### App Configuration
+| Argument         | Source                                        |
+| ---------------- | --------------------------------------------- |
+| `app_name`       | App directory name                            |
+| `node_version`   | `.tool-versions`, required                    |
+| `python_version` | `.tool-versions`, optional                    |
+| `golang_version` | `.tool-versions`, optional                    |
+| `uv_version`     | `.tool-versions`, optional                    |
+| `build_version`  | Semantic version with commit, `v1.2.3-abc1234` |
+| `build_commit`   | Full commit SHA                               |
 
-```json
-{
-  "name": "@your-org/docs",
-  "version": "1.0.0",
-  "publishConfig": {
-    "platform": "gh-pages"
-  },
-  "scripts": {
-    "build": "vitepress build"
-  }
-}
-```
-
-The workflow runs `turbo build --filter=./apps/<app>` and copies the contents of the build output directory (default: `dist`) to the Pages artifact. Set `gh-pages-build-output` if your tool writes to a different directory.
-
-### Enabling in Your Workflow
-
-```yaml
-jobs:
-  polyglot-monorepo-stack:
-    uses: abinnovision/actions/.github/workflows/workflow.yaml@polyglot-monorepo-stack-v1
-    secrets: inherit
-    with:
-      enable-gh-pages: true
-      # Optional: override if your build outputs to a different directory
-      gh-pages-build-output: out
-```
-
-### Repository Setup
-
-1. Go to **Settings → Pages** and set the source to **GitHub Actions**.
-2. Go to **Settings → Environments** and create an environment named **`github-pages`**.
-
-## Docker Build Details
-
-**Automatic Turbo Prune:**
-- The workflow runs `turbo prune --docker` before building images
-- Creates optimized structure in `out/{app-name}/` with `json/` (package files) and `full/` (source)
-- Requires Turbo in root `package.json` and package `name` field in each app's `package.json`
-
-**Available Build Arguments:**
-- `app_name` - Application name from directory
-- `node_version` - Node.js version from `.tool-versions` (required)
-- `python_version` - Python version from `.tool-versions` (optional)
-- `golang_version` - Go version from `.tool-versions` (optional)
-- `uv_version` - UV version from `.tool-versions` (optional)
-- `build_version` - Semantic version with commit (e.g., `v1.2.3-abc1234`)
-- `build_commit` - Full commit SHA
-
-**Example Dockerfile using multiple language versions:**
 ```dockerfile
 ARG node_version
 ARG python_version
-ARG uv_version
 
 FROM node:${node_version}-alpine AS node-builder
-# ... Node.js build steps
-
 FROM python:${python_version}-slim AS python-builder
-# Install UV if version provided
-ARG uv_version
-RUN if [ -n "$uv_version" ]; then pip install uv==${uv_version}; fi
-# ... Python build steps
 ```
 
-**App-Specific Secrets:**
-- Apps can have build-time secrets via the `APP_IMAGE_SECRETS` GitHub secret
-- Use CSV format with structure: `app-name,secret-name,secret-value` (one per line)
-- Example:
-  ```
-  api,NPM_TOKEN,npm_abc123xyz
-  api,SENTRY_TOKEN,abc123
-  frontend,API_KEY,secret-value
-  ```
-- Each secret is available as an individual BuildKit secret mount in your Dockerfile
-- Access secrets using: `--mount=type=secret,id=SECRET_NAME`
-- Secrets are mounted at `/run/secrets/SECRET_NAME` and are not stored in image layers
-- **Example Dockerfile usage:**
-  ```dockerfile
-  RUN --mount=type=secret,id=NPM_TOKEN \
-      npm config set //registry.npmjs.org/:_authToken $(cat /run/secrets/NPM_TOKEN)
-  ```
+### Build secrets
 
-## Turbo Remote Cache in Docker Builds
+Per-app build-time secrets come from the `APP_IMAGE_SECRETS` secret, in CSV format, one per line:
 
-The `Setup Tools` step already used by app builds starts a runner-local Turborepo remote-cache proxy via [`rharkor/caching-for-turbo`](https://github.com/rharkor/caching-for-turbo) (through `setup-node`'s `enable-turbo-cache: auto`), backed by the GitHub Actions cache. The buildx builder is created with `network=host` and the build receives three additional build arguments pointing at that same proxy:
+```
+api,NPM_TOKEN,npm_abc123xyz
+api,SENTRY_TOKEN,abc123
+frontend,API_KEY,secret,with,commas,is,fine
+```
 
-- `TURBO_API` - URL of the runner-local cache proxy (host-reachable `127.0.0.1` address)
-- `TURBO_TEAM` - Team identifier expected by the proxy
-- `TURBO_TOKEN` - Session token of the proxy (local to the job, not a real credential)
-
-These are plain build arguments, not BuildKit secrets.
-
-**Consuming the cache is opt-in per app.** To use it, the app's `Dockerfile` must:
-
-1. Declare `# syntax=docker/dockerfile:1.4` (or newer) as its **first line**
-2. Accept the three build arguments via `ARG`/`ENV`
-3. Annotate the `turbo build` instruction with `--network=host`
-
-**Example Dockerfile:**
+Only the first two commas are delimiters, so values may contain commas. Each entry becomes its own
+BuildKit secret mount, available at `/run/secrets/<name>` and never written to an image layer:
 
 ```dockerfile
-# ...inside your existing build stage
+RUN --mount=type=secret,id=NPM_TOKEN \
+    npm config set //registry.npmjs.org/:_authToken $(cat /run/secrets/NPM_TOKEN)
+```
+
+### Turbo remote cache inside the build
+
+`Setup Tools` starts a runner-local Turborepo cache proxy backed by the Actions cache. The buildx
+builder runs with `network=host` and the build receives `TURBO_API`, `TURBO_TEAM` and `TURBO_TOKEN`
+pointing at that proxy. These are plain build arguments rather than BuildKit secrets; the token is a
+session identifier for the local proxy, not a credential.
+
+Using them is opt-in per app. The `Dockerfile` must declare `# syntax=docker/dockerfile:1.4` or newer
+as its first line, accept the three arguments, and mark the build instruction `--network=host`:
+
+```dockerfile
 ARG TURBO_API
 ARG TURBO_TEAM
 ARG TURBO_TOKEN
@@ -360,48 +278,52 @@ ENV TURBO_TOKEN=${TURBO_TOKEN}
 RUN --network=host turbo build
 ```
 
-Without `--network=host` on the `RUN` instruction, the build cannot reach the proxy and Turbo falls back to a local-only cache.
+Without `--network=host` the build cannot reach the proxy and Turbo silently falls back to a
+local-only cache. Dockerfiles that ignore these arguments are unaffected.
 
-For Dockerfiles that don't reference these build arguments, this is a no-op: the extra arguments stay unused and the build behaves exactly as before.
+## Publishing to GitHub Pages
 
-## Migration from node-monorepo-stack
+A static app opts in by declaring `"publishConfig": { "platform": "gh-pages" }`, matching the
+`publishConfig.language` convention used by packages. Set `enable-gh-pages: true` on the workflow,
+and `gh-pages-build-output` if the build writes somewhere other than `dist`.
 
-To migrate from `node-monorepo-stack` to `polyglot-monorepo-stack`:
+```json
+{
+  "name": "@your-org/docs",
+  "publishConfig": { "platform": "gh-pages" },
+  "scripts": { "build": "vitepress build" }
+}
+```
 
-1. **Create a Makefile** in your repository root:
-   ```makefile
-   .PHONY: install install-immutable
+Only one app per repository may declare the platform. `configure` fails immediately if it finds more,
+since release tracking would otherwise be ambiguous. Deployment is gated on the app being part of a
+release, and prereleases are excluded, so the published site always reflects a tagged version. The
+repository also needs Pages enabled with GitHub Actions as the source, plus a `github-pages`
+environment under Settings → Environments.
 
-   install:
-   	yarn install
+## Dispatching GitOps updates
 
-   install-immutable:
-   	yarn install --immutable
-   ```
+After images are published, the workflow can trigger a deployment workflow in a GitOps repository.
+Configure it with `gitops-app-config` in CSV format, one line per app:
 
-2. **Update your workflow reference**:
-   ```yaml
-   # Before
-   uses: abinnovision/actions/.github/workflows/workflow.yaml@node-monorepo-stack-v1
+```
+app-name,target-repo,dev-application,release-application,registry,image-name
+```
 
-   # After
-   uses: abinnovision/actions/.github/workflows/workflow.yaml@polyglot-monorepo-stack-v1
-   ```
+Only the first five commas are delimiters. A `target-repo` without a slash is resolved against the
+current repository owner. Valid registries are `ghcr`, `gcpar` and `dockerhub`. Apps with incomplete
+rows are skipped with a warning.
 
-3. **(Optional) Tag packages with languages** if you have non-Node.js packages:
-   ```json
-   {
-     "publishConfig": {
-       "language": "python"
-     }
-   }
-   ```
+Releases dispatch against `release-application` and prereleases against `dev-application`. Apps
+sharing a target repository and application are batched into one dispatch, and the dispatch only
+happens if every image in the release was published, so a partial release never reaches your
+cluster.
 
-## Usage
+This requires `token-broker-url` (or the `TOKEN_BROKER_URL` repository variable), which the workflow
+uses to exchange an OIDC token for one scoped to the target repositories. The dispatched workflow
+defaults to `update-tags.yaml` and receives `application` and `updates` inputs.
 
-{{{usage-example type="workflow" name=name inputs=inputs secrets=secrets version=version}}}
-
-## Latest versions
+## Versions
 
 {{{version-examples type="workflow" name=name version=version}}}
 

--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -244,6 +244,8 @@ jobs:
     name: Configure
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       # Commit SHA to check out.
       commit-sha: ${{ steps.commit.outputs.commit_sha }}
@@ -255,14 +257,16 @@ jobs:
       # Apps available for GitHub Pages deployment.
       gh-pages-apps-available: ${{ steps.evaluate.outputs.gh_pages_apps_available }}
     steps:
-      # Resolve the commit SHA based on event type:
-      # pull_request_target: PR head (event runs in base branch context)
-      # push: triggering commit
-      # merge_group: merge commit head
+      # Resolve the commit SHA to check out for this event.
       - name: Evaluate commit
         id: commit
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "PR is #${{ github.event.number }}..."
+              echo "PR Head SHA is ${{ github.event.pull_request.head.sha }}..."
+              echo "commit_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+              echo "::warning::'pull_request_target' is deprecated for polyglot-monorepo-stack: cache writes are denied and fork PRs cannot be checked out. Switch the caller to 'pull_request'."
               echo "PR is #${{ github.event.number }}..."
               echo "PR Head SHA is ${{ github.event.pull_request.head.sha }}..."
               echo "commit_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
@@ -390,6 +394,7 @@ jobs:
       - configure
     permissions:
       contents: read
+      packages: read
       actions: write
     steps:
       - name: Checkout
@@ -433,6 +438,7 @@ jobs:
         test-type: ${{ fromJSON(needs.configure.outputs.test-types-for-matrix) }}
     permissions:
       contents: read
+      packages: read
       actions: write
     steps:
       - name: Checkout
@@ -473,6 +479,8 @@ jobs:
     timeout-minutes: 2
     needs: [configure, release]
     if: always() && !cancelled() && !contains(needs.*.result, 'failure') && needs.release.result == 'success' && needs.release.outputs.versions != '{}'
+    permissions:
+      contents: read
     outputs:
       released-apps: ${{ steps.extract.outputs.released_apps }}
       has-released-apps: ${{ steps.extract.outputs.has_released_apps }}
@@ -1119,6 +1127,7 @@ jobs:
       && needs.publish_prepare.outputs.has-released-gh-pages-apps == 'true'
     permissions:
       contents: read
+      packages: read
       id-token: write
       pages: write
       actions: write


### PR DESCRIPTION
`pull_request_target` runs in the base branch context, so its Actions cache scope is the default branch, which GitHub made read-only for untrusted triggers, and `actions/checkout` now refuses to check out fork PR code under it; the stack therefore resolves the head SHA for `pull_request` as well and warns when a caller still uses `pull_request_target`, which stays supported so consumers can migrate on their own schedule.

This also restores `packages: read` on `check_build` and `test`, which the explicit permissions block added in #518 silently dropped, adds it to `publish_gh_pages`, which never had it, and declares least-privilege permissions on `configure` and `publish_prepare`.

This repository's own CI moves to `pull_request` for the same reasons, since it is public and directly exposed to the checkout guard.

Finally, the `polyglot-monorepo-stack` README is restructured to follow setup order and now documents the trigger and concurrency contract, the required `test-<type>` root scripts and the GitOps configuration, none of which were covered before.

Consumer repositories still on `pull_request_target` need migrating separately, after the `polyglot-monorepo-stack-v2` tag is republished from main.