### PR TITLE
perf(polyglot-monorepo-stack): run test job in parallel with check_build

### DIFF
--- a/workflows/polyglot-monorepo-stack/workflow.yaml
+++ b/workflows/polyglot-monorepo-stack/workflow.yaml
@@ -424,13 +424,13 @@ jobs:
         run: yarn run test-unit
 
   # Run tests in parallel per type (unit tests excluded if run-unit-tests-in-build is set).
+  # Runs concurrently with check_build: neither job consumes build artifacts from the other.
   test:
     name: Test / ${{ matrix.test-type }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:
       - configure
-      - check_build
     if: ${{ fromJSON(needs.configure.outputs.test-types-for-matrix)[0] != null }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- The `test` job re-checks-out, reinstalls, and rebuilds independently of `check_build`, so it never needed to wait for `check_build` to finish.
- Dropped `check_build` from `test`'s `needs:` list so both jobs run concurrently, shortening the pipeline's critical path.
- `release` still explicitly depends on both `check_build` and `test`, so release gating is unaffected.

## Test plan
- [x] `yarn readme:generate` run — no diff (docs already accurate)
- [x] YAML parses cleanly
- [ ] Confirm on a real run that `test` and `check_build` now start concurrently